### PR TITLE
WIP(llgo/rust/opendal): add a opendal demo

### DIFF
--- a/lib/rust/opendal/bindings/c/.gitignore
+++ b/lib/rust/opendal/bindings/c/.gitignore
@@ -1,0 +1,13 @@
+build/
+docs/
+
+*.o
+
+Cargo.lock
+
+examples/*
+!examples/
+!examples/*.h
+!examples/*.c
+!examples/*.cc
+!examples/*.cpp

--- a/lib/rust/opendal/bindings/c/Cargo.toml
+++ b/lib/rust/opendal/bindings/c/Cargo.toml
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+name = "opendal-c"
+publish = false
+
+authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
+edition = "2021"
+homepage = "https://opendal.apache.org/"
+license = "Apache-2.0"
+repository = "https://github.com/apache/opendal"
+rust-version = "1.75"
+version = "0.44.8"
+
+[lib]
+crate-type = ["cdylib", "staticlib"]
+doc = false
+
+[build-dependencies]
+cbindgen = "0.26.0"
+
+[dependencies]
+bytes = "1.4.0"
+once_cell = "1.17.1"
+opendal = { version = "0.47.0", path = "../../core", features = [
+  "layers-blocking",
+  # These are default features before v0.46. TODO: change to optional features #4313
+  "services-azblob",
+  "services-azdls",
+  "services-cos",
+  "services-fs",
+  "services-gcs",
+  "services-ghac",
+  "services-http",
+  "services-ipmfs",
+  "services-memory",
+  "services-obs",
+  "services-oss",
+  "services-s3",
+  "services-webdav",
+  "services-webhdfs",
+  "services-azfile",
+] }
+tokio = { version = "1.27", features = ["fs", "macros", "rt-multi-thread"] }

--- a/lib/rust/opendal/bindings/c/build.rs
+++ b/lib/rust/opendal/bindings/c/build.rs
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+extern crate cbindgen;
+
+use std::path::Path;
+
+fn main() {
+    let header_file = Path::new("include").join("opendal.h");
+
+    cbindgen::generate(".")
+        .expect("Unable to generate bindings")
+        .write_to_file(header_file);
+}

--- a/lib/rust/opendal/bindings/c/cbindgen.toml
+++ b/lib/rust/opendal/bindings/c/cbindgen.toml
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# See https://github.com/eqrion/cbindgen/blob/master/docs.md#cbindgentoml
+# for detailed documentation of every option here.
+
+cpp_compat = true
+documentation_style = "doxy"
+header = """
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+"""
+include_guard = "_OPENDAL_H"
+language = "C"
+no_includes = true
+sys_includes = ["stdint.h", "stddef.h", "stdbool.h"]
+
+[parse]
+include = ["opendal"]
+parse_deps = true

--- a/lib/rust/opendal/bindings/c/examples/basic.c
+++ b/lib/rust/opendal/bindings/c/examples/basic.c
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "assert.h"
+#include "../include/opendal_c.h"
+#include "stdio.h"
+
+int main()
+{
+    /* Initialize a operator for "memory" backend, with no options */
+    opendal_result_operator_new result = opendal_operator_new("memory", 0);
+    assert(result.op != NULL);
+    assert(result.error == NULL);
+
+    opendal_operator* op = result.op;
+
+    /* Prepare some data to be written */
+    opendal_bytes data = {
+        .data = (uint8_t*)"this_string_length_is_24",
+        .len = 24,
+    };
+
+    /* Write this into path "/testpath" */
+    opendal_error* error = opendal_operator_write(op, "/testpath", data);
+    assert(error == NULL);
+
+    /* We can read it out, make sure the data is the same */
+    opendal_result_read r = opendal_operator_read(op, "/testpath");
+    opendal_bytes* read_bytes = r.data;
+    assert(r.error == NULL);
+    assert(read_bytes->len == 24);
+
+    /* Lets print it out */
+    for (int i = 0; i < 24; ++i) {
+        printf("%c", read_bytes->data[i]);
+    }
+    printf("\n");
+
+    /* the opendal_bytes read is heap allocated, please free it */
+    opendal_bytes_free(read_bytes);
+
+    /* the operator_ptr is also heap allocated */
+    opendal_operator_free(op);
+}

--- a/lib/rust/opendal/bindings/c/examples/error_handle.c
+++ b/lib/rust/opendal/bindings/c/examples/error_handle.c
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "assert.h"
+#include "opendal.h"
+#include "stdio.h"
+
+// this example shows how to get error message from opendal_error
+int main()
+{
+    /* Initialize a operator for "memory" backend, with no options */
+    opendal_result_operator_new result = opendal_operator_new("memory", 0);
+    assert(result.op != NULL);
+    assert(result.error == NULL);
+
+    opendal_operator* op = result.op;
+
+    /* The read is supposed to fail */
+    opendal_result_read r = opendal_operator_read(op, "/testpath");
+    assert(r.error != NULL);
+    assert(r.error->code == OPENDAL_NOT_FOUND);
+
+    /* Lets print the error message out */
+    struct opendal_bytes* error_msg = &r.error->message;
+    for (int i = 0; i < error_msg->len; ++i) {
+        printf("%c", error_msg->data[i]);
+    }
+
+    /* free the error since the error is not NULL */
+    opendal_error_free(r.error);
+
+    /* the operator_ptr is also heap allocated */
+    opendal_operator_free(op);
+}

--- a/lib/rust/opendal/bindings/c/include/opendal_c.h
+++ b/lib/rust/opendal/bindings/c/include/opendal_c.h
@@ -1,0 +1,1432 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#ifndef _OPENDAL_H
+#define _OPENDAL_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+/**
+ * \brief The error code for all opendal APIs in C binding.
+ * \todo The error handling is not complete, the error with error message will be
+ * added in the future.
+ */
+typedef enum opendal_code {
+  /**
+   * returning it back. For example, s3 returns an internal service error.
+   */
+  OPENDAL_UNEXPECTED,
+  /**
+   * Underlying service doesn't support this operation.
+   */
+  OPENDAL_UNSUPPORTED,
+  /**
+   * The config for backend is invalid.
+   */
+  OPENDAL_CONFIG_INVALID,
+  /**
+   * The given path is not found.
+   */
+  OPENDAL_NOT_FOUND,
+  /**
+   * The given path doesn't have enough permission for this operation
+   */
+  OPENDAL_PERMISSION_DENIED,
+  /**
+   * The given path is a directory.
+   */
+  OPENDAL_IS_A_DIRECTORY,
+  /**
+   * The given path is not a directory.
+   */
+  OPENDAL_NOT_A_DIRECTORY,
+  /**
+   * The given path already exists thus we failed to the specified operation on it.
+   */
+  OPENDAL_ALREADY_EXISTS,
+  /**
+   * Requests that sent to this path is over the limit, please slow down.
+   */
+  OPENDAL_RATE_LIMITED,
+  /**
+   * The given file paths are same.
+   */
+  OPENDAL_IS_SAME_FILE,
+  /**
+   * The condition of this operation is not match.
+   */
+  OPENDAL_CONDITION_NOT_MATCH,
+  /**
+   * The range of the content is not satisfied.
+   */
+  OPENDAL_RANGE_NOT_SATISFIED,
+} opendal_code;
+
+/**
+ * BlockingLister is designed to list entries at given path in a blocking
+ * manner.
+ *
+ * Users can construct Lister by [`BlockingOperator::lister`] or [`BlockingOperator::lister_with`].
+ *
+ * - Lister implements `Iterator<Item = Result<Entry>>`.
+ * - Lister will return `None` if there is no more entries or error has been returned.
+ */
+typedef struct BlockingLister BlockingLister;
+
+/**
+ * BlockingOperator is the entry for all public blocking APIs.
+ *
+ * Read [`concepts`][docs::concepts] for know more about [`Operator`].
+ *
+ * # Examples
+ *
+ * ## Init backends
+ *
+ * Read more backend init examples in [`services`]
+ *
+ * ```rust,no_run
+ * # use anyhow::Result;
+ * use opendal::services::Fs;
+ * use opendal::BlockingOperator;
+ * use opendal::Operator;
+ *
+ * fn main() -> Result<()> {
+ *     // Create fs backend builder.
+ *     let mut builder = Fs::default();
+ *     // Set the root for fs, all operations will happen under this root.
+ *     //
+ *     // NOTE: the root must be absolute path.
+ *     builder.root("/tmp");
+ *
+ *     // Build an `BlockingOperator` to start operating the storage.
+ *     let _: BlockingOperator = Operator::new(builder)?.finish().blocking();
+ *
+ *     Ok(())
+ * }
+ * ```
+ *
+ * ## Init backends with blocking layer
+ *
+ * Some services like s3, gcs doesn't have native blocking supports, we can use [`layers::BlockingLayer`]
+ * to wrap the async operator to make it blocking.
+ * # use anyhow::Result;
+ * use opendal::layers::BlockingLayer;
+ * use opendal::services::S3;
+ * use opendal::BlockingOperator;
+ * use opendal::Operator;
+ *
+ * async fn test() -> Result<()> {
+ *     // Create fs backend builder.
+ *     let mut builder = S3::default();
+ *     builder.bucket("test");
+ *     builder.region("us-east-1");
+ *
+ *     // Build an `BlockingOperator` with blocking layer to start operating the storage.
+ *     let _: BlockingOperator = Operator::new(builder)?
+ *         .layer(BlockingLayer::create()?)
+ *         .finish()
+ *         .blocking();
+ *
+ *     Ok(())
+ * }
+ * ```
+ */
+typedef struct BlockingOperator BlockingOperator;
+
+/**
+ * Entry returned by [`Lister`] or [`BlockingLister`] to represent a path and it's relative metadata.
+ *
+ * # Notes
+ *
+ * Entry returned by [`Lister`] or [`BlockingLister`] may carry some already known metadata.
+ * Lister by default only make sure that `Mode` is fetched. To make sure the entry contains
+ * metadata you want, please use `list_with` or `lister_with` and `metakey`.
+ *
+ * For example:
+ *
+ * ```no_run
+ * # use anyhow::Result;
+ * use opendal::EntryMode;
+ * use opendal::Metakey;
+ * use opendal::Operator;
+ * # async fn test(op: Operator) -> Result<()> {
+ * let mut entries = op
+ *     .list_with("dir/")
+ *     .metakey(Metakey::ContentLength | Metakey::LastModified)
+ *     .await?;
+ * for entry in entries {
+ *     let meta = entry.metadata();
+ *     match meta.mode() {
+ *         EntryMode::FILE => {
+ *             println!(
+ *                 "Handling file {} with size {}",
+ *                 entry.path(),
+ *                 meta.content_length()
+ *             )
+ *         }
+ *         EntryMode::DIR => {
+ *             println!("Handling dir {}", entry.path())
+ *         }
+ *         EntryMode::Unknown => continue,
+ *     }
+ * }
+ * # Ok(())
+ * # }
+ * ```
+ */
+typedef struct Entry Entry;
+
+typedef struct HashMap_String__String HashMap_String__String;
+
+/**
+ * Metadata carries all metadata associated with a path.
+ *
+ * # Notes
+ *
+ * mode and content_length are required metadata that all services
+ * should provide during `stat` operation. But in `list` operation,
+ * a.k.a., `Entry`'s content length could be `None`.
+ */
+typedef struct Metadata Metadata;
+
+/**
+ * Metadata for operator, users can use this metadata to get information of operator.
+ */
+typedef struct OperatorInfo OperatorInfo;
+
+/**
+ * StdReader is the adapter of [`Read`], [`Seek`] and [`BufRead`] for [`BlockingReader`][crate::BlockingReader].
+ *
+ * Users can use this adapter in cases where they need to use [`Read`] or [`BufRead`] trait.
+ *
+ * StdReader also implements [`Send`] and [`Sync`].
+ */
+typedef struct StdReader StdReader;
+
+/**
+ * \brief opendal_bytes carries raw-bytes with its length
+ *
+ * The opendal_bytes type is a C-compatible substitute for Vec type
+ * in Rust, it has to be manually freed. You have to call opendal_bytes_free()
+ * to free the heap memory to avoid memory leak.
+ *
+ * @see opendal_bytes_free
+ */
+typedef struct opendal_bytes {
+  /**
+   * Pointing to the byte array on heap
+   */
+  const uint8_t *data;
+  /**
+   * The length of the byte array
+   */
+  uintptr_t len;
+} opendal_bytes;
+
+/**
+ * \brief The opendal error type for C binding, containing an error code and corresponding error
+ * message.
+ *
+ * The normal operations returns a pointer to the opendal_error, and the **nullptr normally
+ * represents no error has taken placed**. If any error has taken place, the caller should check
+ * the error code and print the error message.
+ *
+ * The error code is represented in opendal_code, which is a enum on different type of errors.
+ * The error messages is represented in opendal_bytes, which is a non-null terminated byte array.
+ *
+ * \note 1. The error message is on heap, so the error needs to be freed by the caller, by calling
+ *       opendal_error_free. 2. The error message is not null terminated, so the caller should
+ *       never use "%s" to print the error message.
+ *
+ * @see opendal_code
+ * @see opendal_bytes
+ * @see opendal_error_free
+ */
+typedef struct opendal_error {
+  enum opendal_code code;
+  struct opendal_bytes message;
+} opendal_error;
+
+/**
+ * \brief opendal_list_entry is the entry under a path, which is listed from the opendal_lister
+ *
+ * For examples, please see the comment section of opendal_operator_list()
+ * @see opendal_operator_list()
+ * @see opendal_list_entry_path()
+ * @see opendal_list_entry_name()
+ */
+typedef struct opendal_entry {
+  struct Entry *inner;
+} opendal_entry;
+
+/**
+ * \brief The result type returned by opendal_lister_next().
+ * The list entry is the list result of the list operation, the error field is the error code and error message.
+ * If the operation succeeds, the error should be NULL.
+ *
+ * \note Please notice if the lister reaches the end, both the list_entry and error will be NULL.
+ */
+typedef struct opendal_result_lister_next {
+  /**
+   * The next object name
+   */
+  struct opendal_entry *entry;
+  /**
+   * The error, if ok, it is null
+   */
+  struct opendal_error *error;
+} opendal_result_lister_next;
+
+/**
+ * \brief BlockingLister is designed to list entries at given path in a blocking
+ * manner.
+ *
+ * Users can construct Lister by `blocking_list` or `blocking_scan`(currently not supported in C binding)
+ *
+ * For examples, please see the comment section of opendal_operator_list()
+ * @see opendal_operator_list()
+ */
+typedef struct opendal_lister {
+  struct BlockingLister *inner;
+} opendal_lister;
+
+/**
+ * \brief Carries all metadata associated with a **path**.
+ *
+ * The metadata of the "thing" under a path. Please **only** use the opendal_metadata
+ * with our provided API, e.g. opendal_metadata_content_length().
+ *
+ * \note The metadata is also heap-allocated, please call opendal_metadata_free() on this
+ * to free the heap memory.
+ *
+ * @see opendal_metadata_free
+ */
+typedef struct opendal_metadata {
+  /**
+   * The pointer to the opendal::Metadata in the Rust code.
+   * Only touch this on judging whether it is NULL.
+   */
+  struct Metadata *inner;
+} opendal_metadata;
+
+/**
+ * \brief Used to access almost all OpenDAL APIs. It represents a
+ * operator that provides the unified interfaces provided by OpenDAL.
+ *
+ * @see opendal_operator_new This function construct the operator
+ * @see opendal_operator_free This function frees the heap memory of the operator
+ *
+ * \note The opendal_operator actually owns a pointer to
+ * a opendal::BlockingOperator, which is inside the Rust core code.
+ *
+ * \remark You may use the field `ptr` to check whether this is a NULL
+ * operator.
+ */
+typedef struct opendal_operator {
+  /**
+   * The pointer to the opendal::BlockingOperator in the Rust code.
+   * Only touch this on judging whether it is NULL.
+   */
+  const struct BlockingOperator *ptr;
+} opendal_operator;
+
+/**
+ * \brief The result type returned by opendal_operator_new() operation.
+ *
+ * If the init logic is successful, the `op` field will be set to a valid
+ * pointer, and the `error` field will be set to null. If the init logic fails, the
+ * `op` field will be set to null, and the `error` field will be set to a
+ * valid pointer with error code and error message.
+ *
+ * @see opendal_operator_new()
+ * @see opendal_operator
+ * @see opendal_error
+ */
+typedef struct opendal_result_operator_new {
+  /**
+   * The pointer for operator.
+   */
+  struct opendal_operator *op;
+  /**
+   * The error pointer for error.
+   */
+  struct opendal_error *error;
+} opendal_result_operator_new;
+
+/**
+ * \brief The configuration for the initialization of opendal_operator.
+ *
+ * \note This is also a heap-allocated struct, please free it after you use it
+ *
+ * @see opendal_operator_new has an example of using opendal_operator_options
+ * @see opendal_operator_options_new This function construct the operator
+ * @see opendal_operator_options_free This function frees the heap memory of the operator
+ * @see opendal_operator_options_set This function allow you to set the options
+ */
+typedef struct opendal_operator_options {
+  /**
+   * The pointer to the Rust HashMap<String, String>
+   * Only touch this on judging whether it is NULL.
+   */
+  struct HashMap_String__String *inner;
+} opendal_operator_options;
+
+/**
+ * \brief The result type returned by opendal's read operation.
+ *
+ * The result type of read operation in opendal C binding, it contains
+ * the data that the read operation returns and an NULL error.
+ * If the read operation failed, the `data` fields should be a nullptr
+ * and the error is not NULL.
+ */
+typedef struct opendal_result_read {
+  /**
+   * The byte array with length returned by read operations
+   */
+  struct opendal_bytes *data;
+  /**
+   * The error, if ok, it is null
+   */
+  struct opendal_error *error;
+} opendal_result_read;
+
+/**
+ * \brief The result type returned by opendal's reader operation.
+ *
+ * \note The opendal_reader actually owns a pointer to
+ * a opendal::BlockingReader, which is inside the Rust core code.
+ */
+typedef struct opendal_reader {
+  struct StdReader *inner;
+} opendal_reader;
+
+/**
+ * \brief The result type returned by opendal_operator_reader().
+ * The result type for opendal_operator_reader(), the field `reader` contains the reader
+ * of the path, which is an iterator of the objects under the path. the field `code` represents
+ * whether the stat operation is successful.
+ */
+typedef struct opendal_result_operator_reader {
+  /**
+   * The pointer for opendal_reader
+   */
+  struct opendal_reader *reader;
+  /**
+   * The error, if ok, it is null
+   */
+  struct opendal_error *error;
+} opendal_result_operator_reader;
+
+/**
+ * \brief The result type returned by opendal_operator_is_exist().
+ *
+ * The result type for opendal_operator_is_exist(), the field `is_exist`
+ * contains whether the path exists, and the field `error` contains the
+ * corresponding error. If successful, the `error` field is null.
+ *
+ * \note If the opendal_operator_is_exist() fails, the `is_exist` field
+ * will be set to false.
+ */
+typedef struct opendal_result_is_exist {
+  /**
+   * Whether the path exists
+   */
+  bool is_exist;
+  /**
+   * The error, if ok, it is null
+   */
+  struct opendal_error *error;
+} opendal_result_is_exist;
+
+/**
+ * \brief The result type returned by opendal_operator_stat().
+ *
+ * The result type for opendal_operator_stat(), the field `meta` contains the metadata
+ * of the path, the field `error` represents whether the stat operation is successful.
+ * If successful, the `error` field is null.
+ */
+typedef struct opendal_result_stat {
+  /**
+   * The metadata output of the stat
+   */
+  struct opendal_metadata *meta;
+  /**
+   * The error, if ok, it is null
+   */
+  struct opendal_error *error;
+} opendal_result_stat;
+
+/**
+ * \brief The result type returned by opendal_operator_list().
+ *
+ * The result type for opendal_operator_list(), the field `lister` contains the lister
+ * of the path, which is an iterator of the objects under the path. the field `error` represents
+ * whether the stat operation is successful. If successful, the `error` field is null.
+ */
+typedef struct opendal_result_list {
+  /**
+   * The lister, used for further listing operations
+   */
+  struct opendal_lister *lister;
+  /**
+   * The error, if ok, it is null
+   */
+  struct opendal_error *error;
+} opendal_result_list;
+
+/**
+ * \brief Metadata for **operator**, users can use this metadata to get information
+ * of operator.
+ */
+typedef struct opendal_operator_info {
+  struct OperatorInfo *inner;
+} opendal_operator_info;
+
+/**
+ * \brief Capability is used to describe what operations are supported
+ * by current Operator.
+ */
+typedef struct opendal_capability {
+  /**
+   * If operator supports stat.
+   */
+  bool stat;
+  /**
+   * If operator supports stat with if match.
+   */
+  bool stat_with_if_match;
+  /**
+   * If operator supports stat with if none match.
+   */
+  bool stat_with_if_none_match;
+  /**
+   * If operator supports read.
+   */
+  bool read;
+  /**
+   * If operator supports read with if match.
+   */
+  bool read_with_if_match;
+  /**
+   * If operator supports read with if none match.
+   */
+  bool read_with_if_none_match;
+  /**
+   * if operator supports read with override cache control.
+   */
+  bool read_with_override_cache_control;
+  /**
+   * if operator supports read with override content disposition.
+   */
+  bool read_with_override_content_disposition;
+  /**
+   * if operator supports read with override content type.
+   */
+  bool read_with_override_content_type;
+  /**
+   * If operator supports write.
+   */
+  bool write;
+  /**
+   * If operator supports write can be called in multi times.
+   */
+  bool write_can_multi;
+  /**
+   * If operator supports write with empty content.
+   */
+  bool write_can_empty;
+  /**
+   * If operator supports write by append.
+   */
+  bool write_can_append;
+  /**
+   * If operator supports write with content type.
+   */
+  bool write_with_content_type;
+  /**
+   * If operator supports write with content disposition.
+   */
+  bool write_with_content_disposition;
+  /**
+   * If operator supports write with cache control.
+   */
+  bool write_with_cache_control;
+  /**
+   * write_multi_max_size is the max size that services support in write_multi.
+   *
+   * For example, AWS S3 supports 5GiB as max in write_multi.
+   *
+   * If it is not set, this will be zero
+   */
+  uintptr_t write_multi_max_size;
+  /**
+   * write_multi_min_size is the min size that services support in write_multi.
+   *
+   * For example, AWS S3 requires at least 5MiB in write_multi expect the last one.
+   *
+   * If it is not set, this will be zero
+   */
+  uintptr_t write_multi_min_size;
+  /**
+   * write_multi_align_size is the align size that services required in write_multi.
+   *
+   * For example, Google GCS requires align size to 256KiB in write_multi.
+   *
+   * If it is not set, this will be zero
+   */
+  uintptr_t write_multi_align_size;
+  /**
+   * write_total_max_size is the max size that services support in write_total.
+   *
+   * For example, Cloudflare D1 supports 1MB as max in write_total.
+   *
+   * If it is not set, this will be zero
+   */
+  uintptr_t write_total_max_size;
+  /**
+   * If operator supports create dir.
+   */
+  bool create_dir;
+  /**
+   * If operator supports delete.
+   */
+  bool delete_;
+  /**
+   * If operator supports copy.
+   */
+  bool copy;
+  /**
+   * If operator supports rename.
+   */
+  bool rename;
+  /**
+   * If operator supports list.
+   */
+  bool list;
+  /**
+   * If backend supports list with limit.
+   */
+  bool list_with_limit;
+  /**
+   * If backend supports list with start after.
+   */
+  bool list_with_start_after;
+  /**
+   * If backend supports list without delimiter.
+   */
+  bool list_with_recursive;
+  /**
+   * If operator supports presign.
+   */
+  bool presign;
+  /**
+   * If operator supports presign read.
+   */
+  bool presign_read;
+  /**
+   * If operator supports presign stat.
+   */
+  bool presign_stat;
+  /**
+   * If operator supports presign write.
+   */
+  bool presign_write;
+  /**
+   * If operator supports batch.
+   */
+  bool batch;
+  /**
+   * If operator supports batch delete.
+   */
+  bool batch_delete;
+  /**
+   * The max operations that operator supports in batch.
+   *
+   * If it is not set, this will be zero
+   */
+  uintptr_t batch_max_operations;
+  /**
+   * If operator supports blocking.
+   */
+  bool blocking;
+} opendal_capability;
+
+/**
+ * \brief The is the result type returned by opendal_reader_read().
+ * The result type contains a size field, which is the size of the data read,
+ * which is zero on error. The error field is the error code and error message.
+ */
+typedef struct opendal_result_reader_read {
+  /**
+   * The read size if succeed.
+   */
+  uintptr_t size;
+  /**
+   * The error, if ok, it is null
+   */
+  struct opendal_error *error;
+} opendal_result_reader_read;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/**
+ * \brief Frees the opendal_error, ok to call on NULL
+ */
+void opendal_error_free(struct opendal_error *ptr);
+
+/**
+ * \brief Return the next object to be listed
+ *
+ * Lister is an iterator of the objects under its path, this method is the same as
+ * calling next() on the iterator
+ *
+ * For examples, please see the comment section of opendal_operator_list()
+ * @see opendal_operator_list()
+ */
+struct opendal_result_lister_next opendal_lister_next(const struct opendal_lister *self);
+
+/**
+ * \brief Free the heap-allocated metadata used by opendal_lister
+ */
+void opendal_lister_free(const struct opendal_lister *p);
+
+/**
+ * \brief Free the heap-allocated metadata used by opendal_metadata
+ */
+void opendal_metadata_free(struct opendal_metadata *ptr);
+
+/**
+ * \brief Return the content_length of the metadata
+ *
+ * # Example
+ * ```C
+ * // ... previously you wrote "Hello, World!" to path "/testpath"
+ * opendal_result_stat s = opendal_operator_stat(op, "/testpath");
+ * assert(s.error == NULL);
+ *
+ * opendal_metadata *meta = s.meta;
+ * assert(opendal_metadata_content_length(meta) == 13);
+ * ```
+ */
+uint64_t opendal_metadata_content_length(const struct opendal_metadata *self);
+
+/**
+ * \brief Return whether the path represents a file
+ *
+ * # Example
+ * ```C
+ * // ... previously you wrote "Hello, World!" to path "/testpath"
+ * opendal_result_stat s = opendal_operator_stat(op, "/testpath");
+ * assert(s.error == NULL);
+ *
+ * opendal_metadata *meta = s.meta;
+ * assert(opendal_metadata_is_file(meta));
+ * ```
+ */
+bool opendal_metadata_is_file(const struct opendal_metadata *self);
+
+/**
+ * \brief Return whether the path represents a directory
+ *
+ * # Example
+ * ```C
+ * // ... previously you wrote "Hello, World!" to path "/testpath"
+ * opendal_result_stat s = opendal_operator_stat(op, "/testpath");
+ * assert(s.error == NULL);
+ *
+ * opendal_metadata *meta = s.meta;
+ *
+ * // this is not a directory
+ * assert(!opendal_metadata_is_dir(meta));
+ * ```
+ *
+ * \todo This is not a very clear example. A clearer example will be added
+ * after we support opendal_operator_mkdir()
+ */
+bool opendal_metadata_is_dir(const struct opendal_metadata *self);
+
+/**
+ * \brief Return the last_modified of the metadata, in milliseconds
+ *
+ * # Example
+ * ```C
+ * // ... previously you wrote "Hello, World!" to path "/testpath"
+ * opendal_result_stat s = opendal_operator_stat(op, "/testpath");
+ * assert(s.error == NULL);
+ *
+ * opendal_metadata *meta = s.meta;
+ * assert(opendal_metadata_last_modified_ms(meta) != -1);
+ * ```
+ */
+int64_t opendal_metadata_last_modified_ms(const struct opendal_metadata *self);
+
+/**
+ * \brief Free the heap-allocated operator pointed by opendal_operator.
+ *
+ * Please only use this for a pointer pointing at a valid opendal_operator.
+ * Calling this function on NULL does nothing, but calling this function on pointers
+ * of other type will lead to segfault.
+ *
+ * # Example
+ *
+ * ```C
+ * opendal_operator *op = opendal_operator_new("fs", NULL);
+ * // ... use this op, maybe some reads and writes
+ *
+ * // free this operator
+ * opendal_operator_free(op);
+ * ```
+ */
+void opendal_operator_free(const struct opendal_operator *op);
+
+/**
+ * \brief Construct an operator based on `scheme` and `options`
+ *
+ * Uses an array of key-value pairs to initialize the operator based on provided `scheme`
+ * and `options`. For each scheme, i.e. Backend, different options could be set, you may
+ * reference the [documentation](https://opendal.apache.org/docs/category/services/) for
+ * each service, especially for the **Configuration Part**.
+ *
+ * @param scheme the service scheme you want to specify, e.g. "fs", "s3", "supabase"
+ * @param options the pointer to the options for this operators, it could be NULL, which means no
+ * option is set
+ * @see opendal_operator_options
+ * @return A valid opendal_result_operator_new setup with the `scheme` and `options` is the construction
+ * succeeds. On success the operator field is a valid pointer to a newly allocated opendal_operator,
+ * and the error field is NULL. Otherwise, the operator field is a NULL pointer and the error field.
+ *
+ * # Example
+ *
+ * Following is an example.
+ * ```C
+ * // Allocate a new options
+ * opendal_operator_options *options = opendal_operator_options_new();
+ * // Set the options you need
+ * opendal_operator_options_set(options, "root", "/myroot");
+ *
+ * // Construct the operator based on the options and scheme
+ * opendal_result_operator_new result = opendal_operator_new("memory", options);
+ * opendal_operator* op = result.op;
+ *
+ * // you could free the options right away since the options is not used afterwards
+ * opendal_operator_options_free(options);
+ *
+ * // ... your operations
+ * ```
+ *
+ * # Safety
+ *
+ * The only unsafe case is passing a invalid c string pointer to the `scheme` argument.
+ */
+struct opendal_result_operator_new opendal_operator_new(const char *scheme,
+                                                        const struct opendal_operator_options *options);
+
+/**
+ * \brief Blockingly write raw bytes to `path`.
+ *
+ * Write the `bytes` into the `path` blockingly by `op_ptr`.
+ * Error is NULL if successful, otherwise it contains the error code and error message.
+ *
+ * \note It is important to notice that the `bytes` that is passes in will be consumed by this
+ *       function. Therefore, you should not use the `bytes` after this function returns.
+ *
+ * @param op The opendal_operator created previously
+ * @param path The designated path you want to write your bytes in
+ * @param bytes The opendal_byte typed bytes to be written
+ * @see opendal_operator
+ * @see opendal_bytes
+ * @see opendal_error
+ * @return NULL if succeeds, otherwise it contains the error code and error message.
+ *
+ * # Example
+ *
+ * Following is an example
+ * ```C
+ * //...prepare your opendal_operator, named op for example
+ *
+ * // prepare your data
+ * char* data = "Hello, World!";
+ * opendal_bytes bytes = opendal_bytes { .data = (uint8_t*)data, .len = 13 };
+ *
+ * // now you can write!
+ * opendal_error *err = opendal_operator_write(op, "/testpath", bytes);
+ *
+ * // Assert that this succeeds
+ * assert(err == NULL);
+ * ```
+ *
+ * # Safety
+ *
+ * It is **safe** under the cases below
+ * * The memory pointed to by `path` must contain a valid nul terminator at the end of
+ *   the string.
+ * * The `bytes` provided has valid byte in the `data` field and the `len` field is set
+ *   correctly.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics, i.e. exits with information
+ */
+struct opendal_error *opendal_operator_write(const struct opendal_operator *op,
+                                             const char *path,
+                                             struct opendal_bytes bytes);
+
+/**
+ * \brief Blockingly read the data from `path`.
+ *
+ * Read the data out from `path` blockingly by operator.
+ *
+ * @param op The opendal_operator created previously
+ * @param path The path you want to read the data out
+ * @see opendal_operator
+ * @see opendal_result_read
+ * @see opendal_error
+ * @return Returns opendal_result_read, the `data` field is a pointer to a newly allocated
+ * opendal_bytes, the `error` field contains the error. If the `error` is not NULL, then
+ * the operation failed and the `data` field is a nullptr.
+ *
+ * \note If the read operation succeeds, the returned opendal_bytes is newly allocated on heap.
+ * After your usage of that, please call opendal_bytes_free() to free the space.
+ *
+ * # Example
+ *
+ * Following is an example
+ * ```C
+ * // ... you have write "Hello, World!" to path "/testpath"
+ *
+ * opendal_result_read r = opendal_operator_read(op, "testpath");
+ * assert(r.error == NULL);
+ *
+ * opendal_bytes *bytes = r.data;
+ * assert(bytes->len == 13);
+ * ```
+ *
+ * # Safety
+ *
+ * It is **safe** under the cases below
+ * * The memory pointed to by `path` must contain a valid nul terminator at the end of
+ *   the string.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics, i.e. exits with information
+ */
+struct opendal_result_read opendal_operator_read(const struct opendal_operator *op,
+                                                 const char *path);
+
+/**
+ * \brief Blockingly read the data from `path`.
+ *
+ * Read the data out from `path` blockingly by operator, returns
+ * an opendal_result_read with error code.
+ *
+ * @param op The opendal_operator created previously
+ * @param path The path you want to read the data out
+ * @see opendal_operator
+ * @see opendal_result_read
+ * @see opendal_code
+ * @return Returns opendal_code
+ *
+ * \note If the read operation succeeds, the returned opendal_bytes is newly allocated on heap.
+ * After your usage of that, please call opendal_bytes_free() to free the space.
+ *
+ * # Example
+ *
+ * Following is an example
+ * ```C
+ * // ... you have created an operator named op
+ *
+ * opendal_result_operator_reader result = opendal_operator_reader(op, "/testpath");
+ * assert(result.error == NULL);
+ * // The reader is in result.reader
+ * opendal_reader *reader = result.reader;
+ * ```
+ *
+ * # Safety
+ *
+ * It is **safe** under the cases below
+ * * The memory pointed to by `path` must contain a valid nul terminator at the end of
+ *   the string.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics, i.e. exits with information
+ */
+struct opendal_result_operator_reader opendal_operator_reader(const struct opendal_operator *op,
+                                                              const char *path);
+
+/**
+ * \brief Blockingly delete the object in `path`.
+ *
+ * Delete the object in `path` blockingly by `op_ptr`.
+ * Error is NULL if successful, otherwise it contains the error code and error message.
+ *
+ * @param op The opendal_operator created previously
+ * @param path The designated path you want to delete
+ * @see opendal_operator
+ * @see opendal_error
+ * @return NULL if succeeds, otherwise it contains the error code and error message.
+ *
+ * # Example
+ *
+ * Following is an example
+ * ```C
+ * //...prepare your opendal_operator, named op for example
+ *
+ * // prepare your data
+ * char* data = "Hello, World!";
+ * opendal_bytes bytes = opendal_bytes { .data = (uint8_t*)data, .len = 13 };
+ * opendal_error *error = opendal_operator_write(op, "/testpath", bytes);
+ *
+ * assert(error == NULL);
+ *
+ * // now you can delete!
+ * opendal_error *error = opendal_operator_delete(op, "/testpath");
+ *
+ * // Assert that this succeeds
+ * assert(error == NULL);
+ * ```
+ *
+ * # Safety
+ *
+ * It is **safe** under the cases below
+ * * The memory pointed to by `path` must contain a valid nul terminator at the end of
+ *   the string.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics, i.e. exits with information
+ */
+struct opendal_error *opendal_operator_delete(const struct opendal_operator *op, const char *path);
+
+/**
+ * \brief Check whether the path exists.
+ *
+ * If the operation succeeds, no matter the path exists or not,
+ * the error should be a nullptr. Otherwise, the field `is_exist`
+ * is filled with false, and the error is set
+ *
+ * @param op The opendal_operator created previously
+ * @param path The path you want to check existence
+ * @see opendal_operator
+ * @see opendal_result_is_exist
+ * @see opendal_error
+ * @return Returns opendal_result_is_exist, the `is_exist` field contains whether the path exists.
+ * However, it the operation fails, the `is_exist` will contains false and the error will be set.
+ *
+ * # Example
+ *
+ * ```C
+ * // .. you previously wrote some data to path "/mytest/obj"
+ * opendal_result_is_exist e = opendal_operator_is_exist(op, "/mytest/obj");
+ * assert(e.error == NULL);
+ * assert(e.is_exist);
+ *
+ * // but you previously did **not** write any data to path "/yourtest/obj"
+ * opendal_result_is_exist e = opendal_operator_is_exist(op, "/yourtest/obj");
+ * assert(e.error == NULL);
+ * assert(!e.is_exist);
+ * ```
+ *
+ * # Safety
+ *
+ * It is **safe** under the cases below
+ * * The memory pointed to by `path` must contain a valid nul terminator at the end of
+ *   the string.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics, i.e. exits with information
+ */
+struct opendal_result_is_exist opendal_operator_is_exist(const struct opendal_operator *op,
+                                                         const char *path);
+
+/**
+ * \brief Stat the path, return its metadata.
+ *
+ * Error is NULL if successful, otherwise it contains the error code and error message.
+ *
+ * @param op The opendal_operator created previously
+ * @param path The path you want to stat
+ * @see opendal_operator
+ * @see opendal_result_stat
+ * @see opendal_metadata
+ * @return Returns opendal_result_stat, containing a metadata and an opendal_error.
+ * If the operation succeeds, the `meta` field would holds a valid metadata and
+ * the `error` field should hold nullptr. Otherwise the metadata will contain a
+ * NULL pointer, i.e. invalid, and the `error` will be set correspondingly.
+ *
+ * # Example
+ *
+ * ```C
+ * // ... previously you wrote "Hello, World!" to path "/testpath"
+ * opendal_result_stat s = opendal_operator_stat(op, "/testpath");
+ * assert(s.error == NULL);
+ *
+ * const opendal_metadata *meta = s.meta;
+ *
+ * // ... you could now use your metadata, notice that please only access metadata
+ * // using the APIs provided by OpenDAL
+ * ```
+ *
+ * # Safety
+ *
+ * It is **safe** under the cases below
+ * * The memory pointed to by `path` must contain a valid nul terminator at the end of
+ *   the string.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics, i.e. exits with information
+ */
+struct opendal_result_stat opendal_operator_stat(const struct opendal_operator *op,
+                                                 const char *path);
+
+/**
+ * \brief Blockingly list the objects in `path`.
+ *
+ * List the object in `path` blockingly by `op_ptr`, return a result with a
+ * opendal_lister. Users should call opendal_lister_next() on the
+ * lister.
+ *
+ * @param op The opendal_operator created previously
+ * @param path The designated path you want to list
+ * @see opendal_lister
+ * @return Returns opendal_result_list, containing a lister and an opendal_error.
+ * If the operation succeeds, the `lister` field would holds a valid lister and
+ * the `error` field should hold nullptr. Otherwise the `lister`` will contain a
+ * NULL pointer, i.e. invalid, and the `error` will be set correspondingly.
+ *
+ * # Example
+ *
+ * Following is an example
+ * ```C
+ * // You have written some data into some files path "root/dir1"
+ * // Your opendal_operator was called op
+ * opendal_result_list l = opendal_operator_list(op, "root/dir1");
+ * assert(l.error == ERROR);
+ *
+ * opendal_lister *lister = l.lister;
+ * opendal_list_entry *entry;
+ *
+ * while ((entry = opendal_lister_next(lister)) != NULL) {
+ *     const char* de_path = opendal_list_entry_path(entry);
+ *     const char* de_name = opendal_list_entry_name(entry);
+ *     // ...... your operations
+ *
+ *     // remember to free the entry after you are done using it
+ *     opendal_list_entry_free(entry);
+ * }
+ *
+ * // and remember to free the lister
+ * opendal_lister_free(lister);
+ * ```
+ *
+ * # Safety
+ *
+ * It is **safe** under the cases below
+ * * The memory pointed to by `path` must contain a valid nul terminator at the end of
+ *   the string.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics, i.e. exits with information
+ */
+struct opendal_result_list opendal_operator_list(const struct opendal_operator *op,
+                                                 const char *path);
+
+/**
+ * \brief Blockingly create the directory in `path`.
+ *
+ * Create the directory in `path` blockingly by `op_ptr`.
+ * Error is NULL if successful, otherwise it contains the error code and error message.
+ *
+ * @param op The opendal_operator created previously
+ * @param path The designated directory you want to create
+ * @see opendal_operator
+ * @see opendal_error
+ * @return NULL if succeeds, otherwise it contains the error code and error message.
+ *
+ * # Example
+ *
+ * Following is an example
+ * ```C
+ * //...prepare your opendal_operator, named op for example
+ *
+ * // create your directory
+ * opendal_error *error = opendal_operator_create_dir(op, "/testdir/");
+ *
+ * // Assert that this succeeds
+ * assert(error == NULL);
+ * ```
+ *
+ * # Safety
+ *
+ * It is **safe** under the cases below
+ * * The memory pointed to by `path` must contain a valid nul terminator at the end of
+ *   the string.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics, i.e. exits with information
+ */
+struct opendal_error *opendal_operator_create_dir(const struct opendal_operator *op,
+                                                  const char *path);
+
+/**
+ * \brief Blockingly rename the object in `path`.
+ *
+ * Rename the object in `src` to `dest` blockingly by `op`.
+ * Error is NULL if successful, otherwise it contains the error code and error message.
+ *
+ * @param op The opendal_operator created previously
+ * @param src The designated source path you want to rename
+ * @param dest The designated destination path you want to rename
+ * @see opendal_operator
+ * @see opendal_error
+ * @return NULL if succeeds, otherwise it contains the error code and error message.
+ *
+ * # Example
+ *
+ * Following is an example
+ * ```C
+ * //...prepare your opendal_operator, named op for example
+ *
+ * // prepare your data
+ * char* data = "Hello, World!";
+ * opendal_bytes bytes = opendal_bytes { .data = (uint8_t*)data, .len = 13 };
+ * opendal_error *error = opendal_operator_write(op, "/testpath", bytes);
+ *
+ * assert(error == NULL);
+ *
+ * // now you can rename!
+ * opendal_error *error = opendal_operator_rename(op, "/testpath", "/testpath2");
+ *
+ * // Assert that this succeeds
+ * assert(error == NULL);
+ * ```
+ *
+ * # Safety
+ *
+ * It is **safe** under the cases below
+ * * The memory pointed to by `path` must contain a valid nul terminator at the end of
+ *   the string.
+ *
+ * # Panic
+ *
+ * * If the `src` or `dest` points to NULL, this function panics, i.e. exits with information
+ */
+struct opendal_error *opendal_operator_rename(const struct opendal_operator *op,
+                                              const char *src,
+                                              const char *dest);
+
+/**
+ * \brief Blockingly copy the object in `path`.
+ *
+ * Copy the object in `src` to `dest` blockingly by `op`.
+ * Error is NULL if successful, otherwise it contains the error code and error message.
+ *
+ * @param op The opendal_operator created previously
+ * @param src The designated source path you want to copy
+ * @param dest The designated destination path you want to copy
+ * @see opendal_operator
+ * @see opendal_error
+ * @return NULL if succeeds, otherwise it contains the error code and error message.
+ *
+ * # Example
+ *
+ * Following is an example
+ * ```C
+ * //...prepare your opendal_operator, named op for example
+ *
+ * // prepare your data
+ * char* data = "Hello, World!";
+ * opendal_bytes bytes = opendal_bytes { .data = (uint8_t*)data, .len = 13 };
+ * opendal_error *error = opendal_operator_write(op, "/testpath", bytes);
+ *
+ * assert(error == NULL);
+ *
+ * // now you can rename!
+ * opendal_error *error = opendal_operator_copy(op, "/testpath", "/testpath2");
+ *
+ * // Assert that this succeeds
+ * assert(error == NULL);
+ * ```
+ *
+ * # Safety
+ *
+ * It is **safe** under the cases below
+ * * The memory pointed to by `path` must contain a valid nul terminator at the end of
+ *   the string.
+ *
+ * # Panic
+ *
+ * * If the `src` or `dest` points to NULL, this function panics, i.e. exits with information
+ */
+struct opendal_error *opendal_operator_copy(const struct opendal_operator *op,
+                                            const char *src,
+                                            const char *dest);
+
+/**
+ * \brief Get information of underlying accessor.
+ *
+ * # Example
+ *
+ * ```C
+ * /// suppose you have a memory-backed opendal_operator* named op
+ * char *scheme;
+ * opendal_operator_info *info = opendal_operator_info_new(op);
+ *
+ * scheme = opendal_operator_info_get_scheme(info);
+ * assert(!strcmp(scheme, "memory"));
+ *
+ * /// free the heap memory
+ * free(scheme);
+ * opendal_operator_info_free(info);
+ * ```
+ */
+struct opendal_operator_info *opendal_operator_info_new(const struct opendal_operator *op);
+
+/**
+ * \brief Free the heap-allocated opendal_operator_info
+ */
+void opendal_operator_info_free(struct opendal_operator_info *ptr);
+
+/**
+ * \brief Return the nul-terminated operator's scheme, i.e. service
+ *
+ * \note: The string is on heap, remember to free it
+ */
+char *opendal_operator_info_get_scheme(const struct opendal_operator_info *self);
+
+/**
+ * \brief Return the nul-terminated operator's working root path
+ *
+ * \note: The string is on heap, remember to free it
+ */
+char *opendal_operator_info_get_root(const struct opendal_operator_info *self);
+
+/**
+ * \brief Return the nul-terminated operator backend's name, could be empty if underlying backend has no
+ * namespace concept.
+ *
+ * \note: The string is on heap, remember to free it
+ */
+char *opendal_operator_info_get_name(const struct opendal_operator_info *self);
+
+/**
+ * \brief Return the operator's full capability
+ */
+struct opendal_capability opendal_operator_info_get_full_capability(const struct opendal_operator_info *self);
+
+/**
+ * \brief Return the operator's native capability
+ */
+struct opendal_capability opendal_operator_info_get_native_capability(const struct opendal_operator_info *self);
+
+/**
+ * \brief Frees the heap memory used by the opendal_bytes
+ */
+void opendal_bytes_free(struct opendal_bytes *bs);
+
+/**
+ * \brief Construct a heap-allocated opendal_operator_options
+ *
+ * @return An empty opendal_operator_option, which could be set by
+ * opendal_operator_option_set().
+ *
+ * @see opendal_operator_option_set
+ */
+struct opendal_operator_options *opendal_operator_options_new(void);
+
+/**
+ * \brief Set a Key-Value pair inside opendal_operator_options
+ *
+ * # Safety
+ *
+ * This function is unsafe because it dereferences and casts the raw pointers
+ * Make sure the pointer of `key` and `value` point to a valid string.
+ *
+ * # Example
+ *
+ * ```C
+ * opendal_operator_options *options = opendal_operator_options_new();
+ * opendal_operator_options_set(options, "root", "/myroot");
+ *
+ * // .. use your opendal_operator_options
+ *
+ * opendal_operator_options_free(options);
+ * ```
+ */
+void opendal_operator_options_set(struct opendal_operator_options *self,
+                                  const char *key,
+                                  const char *value);
+
+/**
+ * \brief Free the allocated memory used by [`opendal_operator_options`]
+ */
+void opendal_operator_options_free(const struct opendal_operator_options *options);
+
+/**
+ * \brief Path of entry.
+ *
+ * Path is relative to operator's root. Only valid in current operator.
+ *
+ * \note To free the string, you can directly call free()
+ */
+char *opendal_entry_path(const struct opendal_entry *self);
+
+/**
+ * \brief Name of entry.
+ *
+ * Name is the last segment of path.
+ * If this entry is a dir, `Name` MUST endswith `/`
+ * Otherwise, `Name` MUST NOT endswith `/`.
+ *
+ * \note To free the string, you can directly call free()
+ */
+char *opendal_entry_name(const struct opendal_entry *self);
+
+/**
+ * \brief Frees the heap memory used by the opendal_list_entry
+ */
+void opendal_entry_free(struct opendal_entry *ptr);
+
+/**
+ * \brief Read data from the reader.
+ */
+struct opendal_result_reader_read opendal_reader_read(const struct opendal_reader *reader,
+                                                      uint8_t *buf,
+                                                      uintptr_t len);
+
+/**
+ * \brief Frees the heap memory used by the opendal_reader.
+ */
+void opendal_reader_free(struct opendal_reader *ptr);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#endif /* _OPENDAL_H */

--- a/lib/rust/opendal/bindings/c/src/entry.rs
+++ b/lib/rust/opendal/bindings/c/src/entry.rs
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+use ::opendal as core;
+
+/// \brief opendal_list_entry is the entry under a path, which is listed from the opendal_lister
+///
+/// For examples, please see the comment section of opendal_operator_list()
+/// @see opendal_operator_list()
+/// @see opendal_list_entry_path()
+/// @see opendal_list_entry_name()
+#[repr(C)]
+pub struct opendal_entry {
+    inner: *mut core::Entry,
+}
+
+impl opendal_entry {
+    /// Used to convert the Rust type into C type
+    pub(crate) fn new(entry: core::Entry) -> Self {
+        Self {
+            inner: Box::into_raw(Box::new(entry)),
+        }
+    }
+
+    /// \brief Path of entry.
+    ///
+    /// Path is relative to operator's root. Only valid in current operator.
+    ///
+    /// \note To free the string, you can directly call free()
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_entry_path(&self) -> *mut c_char {
+        let s = (*self.inner).path();
+        let c_str = CString::new(s).unwrap();
+        c_str.into_raw()
+    }
+
+    /// \brief Name of entry.
+    ///
+    /// Name is the last segment of path.
+    /// If this entry is a dir, `Name` MUST endswith `/`
+    /// Otherwise, `Name` MUST NOT endswith `/`.
+    ///
+    /// \note To free the string, you can directly call free()
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_entry_name(&self) -> *mut c_char {
+        let s = (*self.inner).name();
+        let c_str = CString::new(s).unwrap();
+        c_str.into_raw()
+    }
+
+    /// \brief Frees the heap memory used by the opendal_list_entry
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_entry_free(ptr: *mut opendal_entry) {
+        if !ptr.is_null() {
+            let _ = unsafe { Box::from_raw((*ptr).inner) };
+            let _ = unsafe { Box::from_raw(ptr) };
+        }
+    }
+}

--- a/lib/rust/opendal/bindings/c/src/error.rs
+++ b/lib/rust/opendal/bindings/c/src/error.rs
@@ -1,0 +1,127 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use ::opendal as core;
+use opendal::Buffer;
+
+use crate::types::opendal_bytes;
+
+/// \brief The error code for all opendal APIs in C binding.
+/// \todo The error handling is not complete, the error with error message will be
+/// added in the future.
+#[repr(C)]
+pub enum opendal_code {
+    /// returning it back. For example, s3 returns an internal service error.
+    OPENDAL_UNEXPECTED,
+    /// Underlying service doesn't support this operation.
+    OPENDAL_UNSUPPORTED,
+    /// The config for backend is invalid.
+    OPENDAL_CONFIG_INVALID,
+    /// The given path is not found.
+    OPENDAL_NOT_FOUND,
+    /// The given path doesn't have enough permission for this operation
+    OPENDAL_PERMISSION_DENIED,
+    /// The given path is a directory.
+    OPENDAL_IS_A_DIRECTORY,
+    /// The given path is not a directory.
+    OPENDAL_NOT_A_DIRECTORY,
+    /// The given path already exists thus we failed to the specified operation on it.
+    OPENDAL_ALREADY_EXISTS,
+    /// Requests that sent to this path is over the limit, please slow down.
+    OPENDAL_RATE_LIMITED,
+    /// The given file paths are same.
+    OPENDAL_IS_SAME_FILE,
+    /// The condition of this operation is not match.
+    OPENDAL_CONDITION_NOT_MATCH,
+    /// The range of the content is not satisfied.
+    OPENDAL_RANGE_NOT_SATISFIED,
+}
+
+impl From<core::ErrorKind> for opendal_code {
+    fn from(value: core::ErrorKind) -> Self {
+        match value {
+            core::ErrorKind::Unexpected => opendal_code::OPENDAL_UNEXPECTED,
+            core::ErrorKind::Unsupported => opendal_code::OPENDAL_UNSUPPORTED,
+            core::ErrorKind::ConfigInvalid => opendal_code::OPENDAL_CONFIG_INVALID,
+            core::ErrorKind::NotFound => opendal_code::OPENDAL_NOT_FOUND,
+            core::ErrorKind::PermissionDenied => opendal_code::OPENDAL_PERMISSION_DENIED,
+            core::ErrorKind::IsADirectory => opendal_code::OPENDAL_IS_A_DIRECTORY,
+            core::ErrorKind::NotADirectory => opendal_code::OPENDAL_NOT_A_DIRECTORY,
+            core::ErrorKind::AlreadyExists => opendal_code::OPENDAL_ALREADY_EXISTS,
+            core::ErrorKind::RateLimited => opendal_code::OPENDAL_RATE_LIMITED,
+            core::ErrorKind::IsSameFile => opendal_code::OPENDAL_IS_SAME_FILE,
+            core::ErrorKind::ConditionNotMatch => opendal_code::OPENDAL_CONDITION_NOT_MATCH,
+            core::ErrorKind::RangeNotSatisfied => opendal_code::OPENDAL_RANGE_NOT_SATISFIED,
+            // if this is triggered, check the [`core`] crate and add a
+            // new error code accordingly
+            _ => panic!("The newly added ErrorKind in core crate is not handled in C bindings"),
+        }
+    }
+}
+
+/// \brief The opendal error type for C binding, containing an error code and corresponding error
+/// message.
+///
+/// The normal operations returns a pointer to the opendal_error, and the **nullptr normally
+/// represents no error has taken placed**. If any error has taken place, the caller should check
+/// the error code and print the error message.
+///
+/// The error code is represented in opendal_code, which is a enum on different type of errors.
+/// The error messages is represented in opendal_bytes, which is a non-null terminated byte array.
+///
+/// \note 1. The error message is on heap, so the error needs to be freed by the caller, by calling
+///       opendal_error_free. 2. The error message is not null terminated, so the caller should
+///       never use "%s" to print the error message.
+///
+/// @see opendal_code
+/// @see opendal_bytes
+/// @see opendal_error_free
+#[repr(C)]
+pub struct opendal_error {
+    code: opendal_code,
+    message: opendal_bytes,
+}
+
+impl opendal_error {
+    /// Create a new opendal error via `core::Error`.
+    ///
+    /// We will call `Box::leak()` to leak this error, so the caller should be responsible for
+    /// free this error.
+    pub fn new(err: core::Error) -> *mut opendal_error {
+        let code = opendal_code::from(err.kind());
+        let message = opendal_bytes::new(Buffer::from(err.to_string()));
+
+        Box::into_raw(Box::new(opendal_error { code, message }))
+    }
+
+    /// \brief Frees the opendal_error, ok to call on NULL
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_error_free(ptr: *mut opendal_error) {
+        if !ptr.is_null() {
+            let message_ptr = &(*ptr).message as *const opendal_bytes as *mut opendal_bytes;
+            if !message_ptr.is_null() {
+                let data_mut = unsafe { (*message_ptr).data as *mut u8 };
+                let _ = unsafe {
+                    Vec::from_raw_parts(data_mut, (*message_ptr).len, (*message_ptr).len)
+                };
+            }
+
+            // free the pointer
+            let _ = unsafe { Box::from_raw(ptr) };
+        }
+    }
+}

--- a/lib/rust/opendal/bindings/c/src/lib.rs
+++ b/lib/rust/opendal/bindings/c/src/lib.rs
@@ -1,0 +1,66 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#![warn(missing_docs)]
+// This crate is the C binding for the OpenDAL project.
+// So it's type node can't meet camel case.
+#![allow(non_camel_case_types)]
+// This crate is the C binding for the OpenDAL project.
+// Nearly all the functions exposed to C FFI are unsafe.
+#![allow(clippy::missing_safety_doc)]
+
+//! The Apache OpenDAL C binding.
+//!
+//! The OpenDAL C binding allows users to utilize the OpenDAL's amazing storage accessing capability
+//! in the C programming language.
+//!
+//! For examples, you may see the examples subdirectory
+
+mod error;
+pub use error::opendal_code;
+pub use error::opendal_error;
+
+mod lister;
+pub use lister::opendal_lister;
+
+mod metadata;
+pub use metadata::opendal_metadata;
+
+mod operator;
+pub use operator::opendal_operator;
+
+mod operator_info;
+
+mod result;
+pub use result::opendal_result_is_exist;
+pub use result::opendal_result_list;
+pub use result::opendal_result_lister_next;
+pub use result::opendal_result_operator_new;
+pub use result::opendal_result_operator_reader;
+pub use result::opendal_result_read;
+pub use result::opendal_result_reader_read;
+pub use result::opendal_result_stat;
+
+mod types;
+pub use types::opendal_bytes;
+pub use types::opendal_operator_options;
+
+mod entry;
+pub use entry::opendal_entry;
+
+mod reader;
+pub use reader::opendal_reader;

--- a/lib/rust/opendal/bindings/c/src/lister.rs
+++ b/lib/rust/opendal/bindings/c/src/lister.rs
@@ -1,0 +1,81 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use ::opendal as core;
+
+use super::*;
+
+/// \brief BlockingLister is designed to list entries at given path in a blocking
+/// manner.
+///
+/// Users can construct Lister by `blocking_list` or `blocking_scan`(currently not supported in C binding)
+///
+/// For examples, please see the comment section of opendal_operator_list()
+/// @see opendal_operator_list()
+#[repr(C)]
+pub struct opendal_lister {
+    inner: *mut core::BlockingLister,
+}
+
+impl opendal_lister {
+    pub(crate) fn new(lister: core::BlockingLister) -> Self {
+        Self {
+            inner: Box::into_raw(Box::new(lister)),
+        }
+    }
+
+    /// \brief Return the next object to be listed
+    ///
+    /// Lister is an iterator of the objects under its path, this method is the same as
+    /// calling next() on the iterator
+    ///
+    /// For examples, please see the comment section of opendal_operator_list()
+    /// @see opendal_operator_list()
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_lister_next(&self) -> opendal_result_lister_next {
+        let e = (*self.inner).next();
+        if e.is_none() {
+            return opendal_result_lister_next {
+                entry: std::ptr::null_mut(),
+                error: std::ptr::null_mut(),
+            };
+        }
+
+        match e.unwrap() {
+            Ok(e) => {
+                let ent = Box::into_raw(Box::new(opendal_entry::new(e)));
+                opendal_result_lister_next {
+                    entry: ent,
+                    error: std::ptr::null_mut(),
+                }
+            }
+            Err(e) => opendal_result_lister_next {
+                entry: std::ptr::null_mut(),
+                error: opendal_error::new(e),
+            },
+        }
+    }
+
+    /// \brief Free the heap-allocated metadata used by opendal_lister
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_lister_free(p: *const opendal_lister) {
+        unsafe {
+            let _ = Box::from_raw((*p).inner);
+            let _ = Box::from_raw(p as *mut opendal_lister);
+        }
+    }
+}

--- a/lib/rust/opendal/bindings/c/src/metadata.rs
+++ b/lib/rust/opendal/bindings/c/src/metadata.rs
@@ -1,0 +1,134 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use ::opendal as core;
+
+/// \brief Carries all metadata associated with a **path**.
+///
+/// The metadata of the "thing" under a path. Please **only** use the opendal_metadata
+/// with our provided API, e.g. opendal_metadata_content_length().
+///
+/// \note The metadata is also heap-allocated, please call opendal_metadata_free() on this
+/// to free the heap memory.
+///
+/// @see opendal_metadata_free
+#[repr(C)]
+pub struct opendal_metadata {
+    /// The pointer to the opendal::Metadata in the Rust code.
+    /// Only touch this on judging whether it is NULL.
+    pub inner: *mut core::Metadata,
+}
+
+impl opendal_metadata {
+    /// Convert a Rust core [`od::Metadata`] into a heap allocated C-compatible
+    /// [`opendal_metadata`]
+    pub(crate) fn new(m: core::Metadata) -> Self {
+        Self {
+            inner: Box::into_raw(Box::new(m)),
+        }
+    }
+
+    /// \brief Free the heap-allocated metadata used by opendal_metadata
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_metadata_free(ptr: *mut opendal_metadata) {
+        unsafe {
+            let _ = Box::from_raw((*ptr).inner);
+            let _ = Box::from_raw(ptr);
+        }
+    }
+
+    /// \brief Return the content_length of the metadata
+    ///
+    /// # Example
+    /// ```C
+    /// // ... previously you wrote "Hello, World!" to path "/testpath"
+    /// opendal_result_stat s = opendal_operator_stat(op, "/testpath");
+    /// assert(s.error == NULL);
+    ///
+    /// opendal_metadata *meta = s.meta;
+    /// assert(opendal_metadata_content_length(meta) == 13);
+    /// ```
+    #[no_mangle]
+    pub extern "C" fn opendal_metadata_content_length(&self) -> u64 {
+        // Safety: the inner should never be null once constructed
+        // The use-after-free is undefined behavior
+        unsafe { (*self.inner).content_length() }
+    }
+
+    /// \brief Return whether the path represents a file
+    ///
+    /// # Example
+    /// ```C
+    /// // ... previously you wrote "Hello, World!" to path "/testpath"
+    /// opendal_result_stat s = opendal_operator_stat(op, "/testpath");
+    /// assert(s.error == NULL);
+    ///
+    /// opendal_metadata *meta = s.meta;
+    /// assert(opendal_metadata_is_file(meta));
+    /// ```
+    #[no_mangle]
+    pub extern "C" fn opendal_metadata_is_file(&self) -> bool {
+        // Safety: the inner should never be null once constructed
+        // The use-after-free is undefined behavior
+        let m = unsafe { &*self.inner };
+
+        m.is_file()
+    }
+
+    /// \brief Return whether the path represents a directory
+    ///
+    /// # Example
+    /// ```C
+    /// // ... previously you wrote "Hello, World!" to path "/testpath"
+    /// opendal_result_stat s = opendal_operator_stat(op, "/testpath");
+    /// assert(s.error == NULL);
+    ///
+    /// opendal_metadata *meta = s.meta;
+    ///
+    /// // this is not a directory
+    /// assert(!opendal_metadata_is_dir(meta));
+    /// ```
+    ///
+    /// \todo This is not a very clear example. A clearer example will be added
+    /// after we support opendal_operator_mkdir()
+    #[no_mangle]
+    pub extern "C" fn opendal_metadata_is_dir(&self) -> bool {
+        // Safety: the inner should never be null once constructed
+        // The use-after-free is undefined behavior
+        unsafe { (*self.inner).is_dir() }
+    }
+
+    /// \brief Return the last_modified of the metadata, in milliseconds
+    ///
+    /// # Example
+    /// ```C
+    /// // ... previously you wrote "Hello, World!" to path "/testpath"
+    /// opendal_result_stat s = opendal_operator_stat(op, "/testpath");
+    /// assert(s.error == NULL);
+    ///
+    /// opendal_metadata *meta = s.meta;
+    /// assert(opendal_metadata_last_modified_ms(meta) != -1);
+    /// ```
+    #[no_mangle]
+    pub extern "C" fn opendal_metadata_last_modified_ms(&self) -> i64 {
+        let mtime = unsafe { (*self.inner).last_modified() };
+        match mtime {
+            None => -1,
+            Some(time) => time.timestamp_millis(),
+        }
+    }
+}

--- a/lib/rust/opendal/bindings/c/src/operator.rs
+++ b/lib/rust/opendal/bindings/c/src/operator.rs
@@ -1,0 +1,815 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+use std::os::raw::c_char;
+use std::str::FromStr;
+
+use ::opendal as core;
+use once_cell::sync::Lazy;
+
+use super::*;
+
+static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+});
+
+/// \brief Used to access almost all OpenDAL APIs. It represents a
+/// operator that provides the unified interfaces provided by OpenDAL.
+///
+/// @see opendal_operator_new This function construct the operator
+/// @see opendal_operator_free This function frees the heap memory of the operator
+///
+/// \note The opendal_operator actually owns a pointer to
+/// a opendal::BlockingOperator, which is inside the Rust core code.
+///
+/// \remark You may use the field `ptr` to check whether this is a NULL
+/// operator.
+#[repr(C)]
+pub struct opendal_operator {
+    /// The pointer to the opendal::BlockingOperator in the Rust code.
+    /// Only touch this on judging whether it is NULL.
+    ptr: *const core::BlockingOperator,
+}
+
+impl opendal_operator {
+    /// \brief Free the heap-allocated operator pointed by opendal_operator.
+    ///
+    /// Please only use this for a pointer pointing at a valid opendal_operator.
+    /// Calling this function on NULL does nothing, but calling this function on pointers
+    /// of other type will lead to segfault.
+    ///
+    /// # Example
+    ///
+    /// ```C
+    /// opendal_operator *op = opendal_operator_new("fs", NULL);
+    /// // ... use this op, maybe some reads and writes
+    ///
+    /// // free this operator
+    /// opendal_operator_free(op);
+    /// ```
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_operator_free(op: *const opendal_operator) {
+        let _ = unsafe { Box::from_raw((*op).ptr as *mut core::BlockingOperator) };
+        let _ = unsafe { Box::from_raw(op as *mut opendal_operator) };
+    }
+}
+
+/// Returns a reference to the underlying [`od::BlockingOperator`]
+///
+/// # Safety
+///
+/// The ptr is a raw pointer to the underlying [`od::BlockingOperator`].
+/// It will only free when opendal_operator_free has been called.
+impl AsRef<core::BlockingOperator> for opendal_operator {
+    fn as_ref(&self) -> &core::BlockingOperator {
+        unsafe { &*(self.ptr) }
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl From<*const core::BlockingOperator> for opendal_operator {
+    fn from(value: *const core::BlockingOperator) -> Self {
+        Self { ptr: value }
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl From<*mut core::BlockingOperator> for opendal_operator {
+    fn from(value: *mut core::BlockingOperator) -> Self {
+        Self { ptr: value }
+    }
+}
+
+fn build_operator(
+    schema: core::Scheme,
+    map: HashMap<String, String>,
+) -> core::Result<core::Operator> {
+    let mut op = match core::Operator::via_map(schema, map) {
+        Ok(o) => o,
+        Err(e) => return Err(e),
+    };
+    if !op.info().full_capability().blocking {
+        let runtime =
+            tokio::runtime::Handle::try_current().unwrap_or_else(|_| RUNTIME.handle().clone());
+        let _guard = runtime.enter();
+        op = op
+            .layer(core::layers::BlockingLayer::create().expect("blocking layer must be created"));
+    }
+    Ok(op)
+}
+
+/// \brief Construct an operator based on `scheme` and `options`
+///
+/// Uses an array of key-value pairs to initialize the operator based on provided `scheme`
+/// and `options`. For each scheme, i.e. Backend, different options could be set, you may
+/// reference the [documentation](https://opendal.apache.org/docs/category/services/) for
+/// each service, especially for the **Configuration Part**.
+///
+/// @param scheme the service scheme you want to specify, e.g. "fs", "s3", "supabase"
+/// @param options the pointer to the options for this operators, it could be NULL, which means no
+/// option is set
+/// @see opendal_operator_options
+/// @return A valid opendal_result_operator_new setup with the `scheme` and `options` is the construction
+/// succeeds. On success the operator field is a valid pointer to a newly allocated opendal_operator,
+/// and the error field is NULL. Otherwise, the operator field is a NULL pointer and the error field.
+///
+/// # Example
+///
+/// Following is an example.
+/// ```C
+/// // Allocate a new options
+/// opendal_operator_options *options = opendal_operator_options_new();
+/// // Set the options you need
+/// opendal_operator_options_set(options, "root", "/myroot");
+///
+/// // Construct the operator based on the options and scheme
+/// opendal_result_operator_new result = opendal_operator_new("memory", options);
+/// opendal_operator* op = result.op;
+///
+/// // you could free the options right away since the options is not used afterwards
+/// opendal_operator_options_free(options);
+///
+/// // ... your operations
+/// ```
+///
+/// # Safety
+///
+/// The only unsafe case is passing a invalid c string pointer to the `scheme` argument.
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_new(
+    scheme: *const c_char,
+    options: *const opendal_operator_options,
+) -> opendal_result_operator_new {
+    if scheme.is_null() {
+        panic!("The scheme given is pointing at NULL");
+    }
+
+    let scheme_str = unsafe { std::ffi::CStr::from_ptr(scheme).to_str().unwrap() };
+    let scheme = match core::Scheme::from_str(scheme_str) {
+        Ok(s) => s,
+        Err(e) => {
+            return opendal_result_operator_new {
+                op: std::ptr::null_mut(),
+                error: opendal_error::new(e),
+            };
+        }
+    };
+
+    let mut map = HashMap::default();
+    if !options.is_null() {
+        for (k, v) in (*options).as_ref() {
+            map.insert(k.to_string(), v.to_string());
+        }
+    }
+
+    match build_operator(scheme, map) {
+        Ok(op) => {
+            let op = opendal_operator::from(Box::into_raw(Box::new(op.blocking())));
+            opendal_result_operator_new {
+                op: Box::into_raw(Box::new(op)),
+                error: std::ptr::null_mut(),
+            }
+        }
+        Err(e) => opendal_result_operator_new {
+            op: std::ptr::null_mut(),
+            error: opendal_error::new(e),
+        },
+    }
+}
+
+/// \brief Blockingly write raw bytes to `path`.
+///
+/// Write the `bytes` into the `path` blockingly by `op_ptr`.
+/// Error is NULL if successful, otherwise it contains the error code and error message.
+///
+/// \note It is important to notice that the `bytes` that is passes in will be consumed by this
+///       function. Therefore, you should not use the `bytes` after this function returns.
+///
+/// @param op The opendal_operator created previously
+/// @param path The designated path you want to write your bytes in
+/// @param bytes The opendal_byte typed bytes to be written
+/// @see opendal_operator
+/// @see opendal_bytes
+/// @see opendal_error
+/// @return NULL if succeeds, otherwise it contains the error code and error message.
+///
+/// # Example
+///
+/// Following is an example
+/// ```C
+/// //...prepare your opendal_operator, named op for example
+///
+/// // prepare your data
+/// char* data = "Hello, World!";
+/// opendal_bytes bytes = opendal_bytes { .data = (uint8_t*)data, .len = 13 };
+///
+/// // now you can write!
+/// opendal_error *err = opendal_operator_write(op, "/testpath", bytes);
+///
+/// // Assert that this succeeds
+/// assert(err == NULL);
+/// ```
+///
+/// # Safety
+///
+/// It is **safe** under the cases below
+/// * The memory pointed to by `path` must contain a valid nul terminator at the end of
+///   the string.
+/// * The `bytes` provided has valid byte in the `data` field and the `len` field is set
+///   correctly.
+///
+/// # Panic
+///
+/// * If the `path` points to NULL, this function panics, i.e. exits with information
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_write(
+    op: *const opendal_operator,
+    path: *const c_char,
+    bytes: opendal_bytes,
+) -> *mut opendal_error {
+    if path.is_null() {
+        panic!("The path given is pointing at NULL");
+    }
+
+    let op = (*op).as_ref();
+    let path = unsafe { std::ffi::CStr::from_ptr(path).to_str().unwrap() };
+    match op.write(path, bytes) {
+        Ok(_) => std::ptr::null_mut(),
+        Err(e) => opendal_error::new(e),
+    }
+}
+
+/// \brief Blockingly read the data from `path`.
+///
+/// Read the data out from `path` blockingly by operator.
+///
+/// @param op The opendal_operator created previously
+/// @param path The path you want to read the data out
+/// @see opendal_operator
+/// @see opendal_result_read
+/// @see opendal_error
+/// @return Returns opendal_result_read, the `data` field is a pointer to a newly allocated
+/// opendal_bytes, the `error` field contains the error. If the `error` is not NULL, then
+/// the operation failed and the `data` field is a nullptr.
+///
+/// \note If the read operation succeeds, the returned opendal_bytes is newly allocated on heap.
+/// After your usage of that, please call opendal_bytes_free() to free the space.
+///
+/// # Example
+///
+/// Following is an example
+/// ```C
+/// // ... you have write "Hello, World!" to path "/testpath"
+///
+/// opendal_result_read r = opendal_operator_read(op, "testpath");
+/// assert(r.error == NULL);
+///
+/// opendal_bytes *bytes = r.data;
+/// assert(bytes->len == 13);
+/// ```
+///
+/// # Safety
+///
+/// It is **safe** under the cases below
+/// * The memory pointed to by `path` must contain a valid nul terminator at the end of
+///   the string.
+///
+/// # Panic
+///
+/// * If the `path` points to NULL, this function panics, i.e. exits with information
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_read(
+    op: *const opendal_operator,
+    path: *const c_char,
+) -> opendal_result_read {
+    if path.is_null() {
+        panic!("The path given is pointing at NULL");
+    }
+
+    let op = (*op).as_ref();
+    let path = unsafe { std::ffi::CStr::from_ptr(path).to_str().unwrap() };
+    let data = op.read(path);
+    match data {
+        Ok(d) => {
+            let v = Box::new(opendal_bytes::new(d));
+            opendal_result_read {
+                data: Box::into_raw(v),
+                error: std::ptr::null_mut(),
+            }
+        }
+        Err(e) => opendal_result_read {
+            data: std::ptr::null_mut(),
+            error: opendal_error::new(e),
+        },
+    }
+}
+
+/// \brief Blockingly read the data from `path`.
+///
+/// Read the data out from `path` blockingly by operator, returns
+/// an opendal_result_read with error code.
+///
+/// @param op The opendal_operator created previously
+/// @param path The path you want to read the data out
+/// @see opendal_operator
+/// @see opendal_result_read
+/// @see opendal_code
+/// @return Returns opendal_code
+///
+/// \note If the read operation succeeds, the returned opendal_bytes is newly allocated on heap.
+/// After your usage of that, please call opendal_bytes_free() to free the space.
+///
+/// # Example
+///
+/// Following is an example
+/// ```C
+/// // ... you have created an operator named op
+///
+/// opendal_result_operator_reader result = opendal_operator_reader(op, "/testpath");
+/// assert(result.error == NULL);
+/// // The reader is in result.reader
+/// opendal_reader *reader = result.reader;
+/// ```
+///
+/// # Safety
+///
+/// It is **safe** under the cases below
+/// * The memory pointed to by `path` must contain a valid nul terminator at the end of
+///   the string.
+///
+/// # Panic
+///
+/// * If the `path` points to NULL, this function panics, i.e. exits with information
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_reader(
+    op: *const opendal_operator,
+    path: *const c_char,
+) -> opendal_result_operator_reader {
+    if path.is_null() {
+        panic!("The path given is pointing at NULL");
+    }
+    let op = (*op).as_ref();
+
+    let path = unsafe { std::ffi::CStr::from_ptr(path).to_str().unwrap() };
+    let reader = match op.reader(path) {
+        Ok(reader) => reader,
+        Err(err) => {
+            return opendal_result_operator_reader {
+                reader: std::ptr::null_mut(),
+                error: opendal_error::new(err),
+            }
+        }
+    };
+
+    match reader.into_std_read(..) {
+        Ok(reader) => opendal_result_operator_reader {
+            reader: Box::into_raw(Box::new(opendal_reader::new(reader))),
+            error: std::ptr::null_mut(),
+        },
+        Err(e) => opendal_result_operator_reader {
+            reader: std::ptr::null_mut(),
+            error: opendal_error::new(e),
+        },
+    }
+}
+
+/// \brief Blockingly delete the object in `path`.
+///
+/// Delete the object in `path` blockingly by `op_ptr`.
+/// Error is NULL if successful, otherwise it contains the error code and error message.
+///
+/// @param op The opendal_operator created previously
+/// @param path The designated path you want to delete
+/// @see opendal_operator
+/// @see opendal_error
+/// @return NULL if succeeds, otherwise it contains the error code and error message.
+///
+/// # Example
+///
+/// Following is an example
+/// ```C
+/// //...prepare your opendal_operator, named op for example
+///
+/// // prepare your data
+/// char* data = "Hello, World!";
+/// opendal_bytes bytes = opendal_bytes { .data = (uint8_t*)data, .len = 13 };
+/// opendal_error *error = opendal_operator_write(op, "/testpath", bytes);
+///
+/// assert(error == NULL);
+///
+/// // now you can delete!
+/// opendal_error *error = opendal_operator_delete(op, "/testpath");
+///
+/// // Assert that this succeeds
+/// assert(error == NULL);
+/// ```
+///
+/// # Safety
+///
+/// It is **safe** under the cases below
+/// * The memory pointed to by `path` must contain a valid nul terminator at the end of
+///   the string.
+///
+/// # Panic
+///
+/// * If the `path` points to NULL, this function panics, i.e. exits with information
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_delete(
+    op: *const opendal_operator,
+    path: *const c_char,
+) -> *mut opendal_error {
+    if path.is_null() {
+        panic!("The path given is pointing at NULL");
+    }
+
+    let op = (*op).as_ref();
+    let path = unsafe { std::ffi::CStr::from_ptr(path).to_str().unwrap() };
+    match op.delete(path) {
+        Ok(_) => std::ptr::null_mut(),
+        Err(e) => opendal_error::new(e),
+    }
+}
+
+/// \brief Check whether the path exists.
+///
+/// If the operation succeeds, no matter the path exists or not,
+/// the error should be a nullptr. Otherwise, the field `is_exist`
+/// is filled with false, and the error is set
+///
+/// @param op The opendal_operator created previously
+/// @param path The path you want to check existence
+/// @see opendal_operator
+/// @see opendal_result_is_exist
+/// @see opendal_error
+/// @return Returns opendal_result_is_exist, the `is_exist` field contains whether the path exists.
+/// However, it the operation fails, the `is_exist` will contains false and the error will be set.
+///
+/// # Example
+///
+/// ```C
+/// // .. you previously wrote some data to path "/mytest/obj"
+/// opendal_result_is_exist e = opendal_operator_is_exist(op, "/mytest/obj");
+/// assert(e.error == NULL);
+/// assert(e.is_exist);
+///
+/// // but you previously did **not** write any data to path "/yourtest/obj"
+/// opendal_result_is_exist e = opendal_operator_is_exist(op, "/yourtest/obj");
+/// assert(e.error == NULL);
+/// assert(!e.is_exist);
+/// ```
+///
+/// # Safety
+///
+/// It is **safe** under the cases below
+/// * The memory pointed to by `path` must contain a valid nul terminator at the end of
+///   the string.
+///
+/// # Panic
+///
+/// * If the `path` points to NULL, this function panics, i.e. exits with information
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_is_exist(
+    op: *const opendal_operator,
+    path: *const c_char,
+) -> opendal_result_is_exist {
+    if path.is_null() {
+        panic!("The path given is pointing at NULL");
+    }
+
+    let op = (*op).as_ref();
+    let path = unsafe { std::ffi::CStr::from_ptr(path).to_str().unwrap() };
+    match op.is_exist(path) {
+        Ok(e) => opendal_result_is_exist {
+            is_exist: e,
+            error: std::ptr::null_mut(),
+        },
+        Err(e) => opendal_result_is_exist {
+            is_exist: false,
+            error: opendal_error::new(e),
+        },
+    }
+}
+
+/// \brief Stat the path, return its metadata.
+///
+/// Error is NULL if successful, otherwise it contains the error code and error message.
+///
+/// @param op The opendal_operator created previously
+/// @param path The path you want to stat
+/// @see opendal_operator
+/// @see opendal_result_stat
+/// @see opendal_metadata
+/// @return Returns opendal_result_stat, containing a metadata and an opendal_error.
+/// If the operation succeeds, the `meta` field would holds a valid metadata and
+/// the `error` field should hold nullptr. Otherwise the metadata will contain a
+/// NULL pointer, i.e. invalid, and the `error` will be set correspondingly.
+///
+/// # Example
+///
+/// ```C
+/// // ... previously you wrote "Hello, World!" to path "/testpath"
+/// opendal_result_stat s = opendal_operator_stat(op, "/testpath");
+/// assert(s.error == NULL);
+///
+/// const opendal_metadata *meta = s.meta;
+///
+/// // ... you could now use your metadata, notice that please only access metadata
+/// // using the APIs provided by OpenDAL
+/// ```
+///
+/// # Safety
+///
+/// It is **safe** under the cases below
+/// * The memory pointed to by `path` must contain a valid nul terminator at the end of
+///   the string.
+///
+/// # Panic
+///
+/// * If the `path` points to NULL, this function panics, i.e. exits with information
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_stat(
+    op: *const opendal_operator,
+    path: *const c_char,
+) -> opendal_result_stat {
+    if path.is_null() {
+        panic!("The path given is pointing at NULL");
+    }
+
+    let op = (*op).as_ref();
+    let path = unsafe { std::ffi::CStr::from_ptr(path).to_str().unwrap() };
+    match op.stat(path) {
+        Ok(m) => opendal_result_stat {
+            meta: Box::into_raw(Box::new(opendal_metadata::new(m))),
+            error: std::ptr::null_mut(),
+        },
+        Err(e) => opendal_result_stat {
+            meta: std::ptr::null_mut(),
+            error: opendal_error::new(e),
+        },
+    }
+}
+
+/// \brief Blockingly list the objects in `path`.
+///
+/// List the object in `path` blockingly by `op_ptr`, return a result with a
+/// opendal_lister. Users should call opendal_lister_next() on the
+/// lister.
+///
+/// @param op The opendal_operator created previously
+/// @param path The designated path you want to list
+/// @see opendal_lister
+/// @return Returns opendal_result_list, containing a lister and an opendal_error.
+/// If the operation succeeds, the `lister` field would holds a valid lister and
+/// the `error` field should hold nullptr. Otherwise the `lister`` will contain a
+/// NULL pointer, i.e. invalid, and the `error` will be set correspondingly.
+///
+/// # Example
+///
+/// Following is an example
+/// ```C
+/// // You have written some data into some files path "root/dir1"
+/// // Your opendal_operator was called op
+/// opendal_result_list l = opendal_operator_list(op, "root/dir1");
+/// assert(l.error == ERROR);
+///
+/// opendal_lister *lister = l.lister;
+/// opendal_list_entry *entry;
+///
+/// while ((entry = opendal_lister_next(lister)) != NULL) {
+///     const char* de_path = opendal_list_entry_path(entry);
+///     const char* de_name = opendal_list_entry_name(entry);
+///     // ...... your operations
+///
+///     // remember to free the entry after you are done using it
+///     opendal_list_entry_free(entry);
+/// }
+///
+/// // and remember to free the lister
+/// opendal_lister_free(lister);
+/// ```
+///
+/// # Safety
+///
+/// It is **safe** under the cases below
+/// * The memory pointed to by `path` must contain a valid nul terminator at the end of
+///   the string.
+///
+/// # Panic
+///
+/// * If the `path` points to NULL, this function panics, i.e. exits with information
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_list(
+    op: *const opendal_operator,
+    path: *const c_char,
+) -> opendal_result_list {
+    if path.is_null() {
+        panic!("The path given is pointing at NULL");
+    }
+
+    let op = (*op).as_ref();
+    let path = unsafe { std::ffi::CStr::from_ptr(path).to_str().unwrap() };
+    match op.lister(path) {
+        Ok(lister) => opendal_result_list {
+            lister: Box::into_raw(Box::new(opendal_lister::new(lister))),
+            error: std::ptr::null_mut(),
+        },
+        Err(e) => opendal_result_list {
+            lister: std::ptr::null_mut(),
+            error: opendal_error::new(e),
+        },
+    }
+}
+
+/// \brief Blockingly create the directory in `path`.
+///
+/// Create the directory in `path` blockingly by `op_ptr`.
+/// Error is NULL if successful, otherwise it contains the error code and error message.
+///
+/// @param op The opendal_operator created previously
+/// @param path The designated directory you want to create
+/// @see opendal_operator
+/// @see opendal_error
+/// @return NULL if succeeds, otherwise it contains the error code and error message.
+///
+/// # Example
+///
+/// Following is an example
+/// ```C
+/// //...prepare your opendal_operator, named op for example
+///
+/// // create your directory
+/// opendal_error *error = opendal_operator_create_dir(op, "/testdir/");
+///
+/// // Assert that this succeeds
+/// assert(error == NULL);
+/// ```
+///
+/// # Safety
+///
+/// It is **safe** under the cases below
+/// * The memory pointed to by `path` must contain a valid nul terminator at the end of
+///   the string.
+///
+/// # Panic
+///
+/// * If the `path` points to NULL, this function panics, i.e. exits with information
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_create_dir(
+    op: *const opendal_operator,
+    path: *const c_char,
+) -> *mut opendal_error {
+    if path.is_null() {
+        panic!("The path given is pointing at NULL");
+    }
+
+    let op = (*op).as_ref();
+    let path = unsafe { std::ffi::CStr::from_ptr(path).to_str().unwrap() };
+    match op.create_dir(path) {
+        Ok(_) => std::ptr::null_mut(),
+        Err(e) => opendal_error::new(e),
+    }
+}
+
+/// \brief Blockingly rename the object in `path`.
+///
+/// Rename the object in `src` to `dest` blockingly by `op`.
+/// Error is NULL if successful, otherwise it contains the error code and error message.
+///
+/// @param op The opendal_operator created previously
+/// @param src The designated source path you want to rename
+/// @param dest The designated destination path you want to rename
+/// @see opendal_operator
+/// @see opendal_error
+/// @return NULL if succeeds, otherwise it contains the error code and error message.
+///
+/// # Example
+///
+/// Following is an example
+/// ```C
+/// //...prepare your opendal_operator, named op for example
+///
+/// // prepare your data
+/// char* data = "Hello, World!";
+/// opendal_bytes bytes = opendal_bytes { .data = (uint8_t*)data, .len = 13 };
+/// opendal_error *error = opendal_operator_write(op, "/testpath", bytes);
+///
+/// assert(error == NULL);
+///
+/// // now you can rename!
+/// opendal_error *error = opendal_operator_rename(op, "/testpath", "/testpath2");
+///
+/// // Assert that this succeeds
+/// assert(error == NULL);
+/// ```
+///
+/// # Safety
+///
+/// It is **safe** under the cases below
+/// * The memory pointed to by `path` must contain a valid nul terminator at the end of
+///   the string.
+///
+/// # Panic
+///
+/// * If the `src` or `dest` points to NULL, this function panics, i.e. exits with information
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_rename(
+    op: *const opendal_operator,
+    src: *const c_char,
+    dest: *const c_char,
+) -> *mut opendal_error {
+    if src.is_null() {
+        panic!("The source path given is pointing at NULL");
+    }
+    if dest.is_null() {
+        panic!("The destination path given is pointing at NULL");
+    }
+
+    let op = (*op).as_ref();
+    let src = unsafe { std::ffi::CStr::from_ptr(src).to_str().unwrap() };
+    let dest = unsafe { std::ffi::CStr::from_ptr(dest).to_str().unwrap() };
+    match op.rename(src, dest) {
+        Ok(_) => std::ptr::null_mut(),
+        Err(e) => opendal_error::new(e),
+    }
+}
+
+/// \brief Blockingly copy the object in `path`.
+///
+/// Copy the object in `src` to `dest` blockingly by `op`.
+/// Error is NULL if successful, otherwise it contains the error code and error message.
+///
+/// @param op The opendal_operator created previously
+/// @param src The designated source path you want to copy
+/// @param dest The designated destination path you want to copy
+/// @see opendal_operator
+/// @see opendal_error
+/// @return NULL if succeeds, otherwise it contains the error code and error message.
+///
+/// # Example
+///
+/// Following is an example
+/// ```C
+/// //...prepare your opendal_operator, named op for example
+///
+/// // prepare your data
+/// char* data = "Hello, World!";
+/// opendal_bytes bytes = opendal_bytes { .data = (uint8_t*)data, .len = 13 };
+/// opendal_error *error = opendal_operator_write(op, "/testpath", bytes);
+///
+/// assert(error == NULL);
+///
+/// // now you can rename!
+/// opendal_error *error = opendal_operator_copy(op, "/testpath", "/testpath2");
+///
+/// // Assert that this succeeds
+/// assert(error == NULL);
+/// ```
+///
+/// # Safety
+///
+/// It is **safe** under the cases below
+/// * The memory pointed to by `path` must contain a valid nul terminator at the end of
+///   the string.
+///
+/// # Panic
+///
+/// * If the `src` or `dest` points to NULL, this function panics, i.e. exits with information
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_copy(
+    op: *const opendal_operator,
+    src: *const c_char,
+    dest: *const c_char,
+) -> *mut opendal_error {
+    if src.is_null() {
+        panic!("The source path given is pointing at NULL");
+    }
+    if dest.is_null() {
+        panic!("The destination path given is pointing at NULL");
+    }
+
+    let op = (*op).as_ref();
+    let src = unsafe { std::ffi::CStr::from_ptr(src).to_str().unwrap() };
+    let dest = unsafe { std::ffi::CStr::from_ptr(dest).to_str().unwrap() };
+    match op.copy(src, dest) {
+        Ok(_) => std::ptr::null_mut(),
+        Err(e) => opendal_error::new(e),
+    }
+}

--- a/lib/rust/opendal/bindings/c/src/operator_info.rs
+++ b/lib/rust/opendal/bindings/c/src/operator_info.rs
@@ -1,0 +1,268 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::ffi::c_char;
+use std::ffi::CString;
+
+use ::opendal as core;
+
+use crate::opendal_operator;
+
+/// \brief Metadata for **operator**, users can use this metadata to get information
+/// of operator.
+#[repr(C)]
+pub struct opendal_operator_info {
+    pub inner: *mut core::OperatorInfo,
+}
+
+/// \brief Capability is used to describe what operations are supported
+/// by current Operator.
+#[repr(C)]
+pub struct opendal_capability {
+    /// If operator supports stat.
+    pub stat: bool,
+    /// If operator supports stat with if match.
+    pub stat_with_if_match: bool,
+    /// If operator supports stat with if none match.
+    pub stat_with_if_none_match: bool,
+
+    /// If operator supports read.
+    pub read: bool,
+    /// If operator supports read with if match.
+    pub read_with_if_match: bool,
+    /// If operator supports read with if none match.
+    pub read_with_if_none_match: bool,
+    /// if operator supports read with override cache control.
+    pub read_with_override_cache_control: bool,
+    /// if operator supports read with override content disposition.
+    pub read_with_override_content_disposition: bool,
+    /// if operator supports read with override content type.
+    pub read_with_override_content_type: bool,
+
+    /// If operator supports write.
+    pub write: bool,
+    /// If operator supports write can be called in multi times.
+    pub write_can_multi: bool,
+    /// If operator supports write with empty content.
+    pub write_can_empty: bool,
+    /// If operator supports write by append.
+    pub write_can_append: bool,
+    /// If operator supports write with content type.
+    pub write_with_content_type: bool,
+    /// If operator supports write with content disposition.
+    pub write_with_content_disposition: bool,
+    /// If operator supports write with cache control.
+    pub write_with_cache_control: bool,
+    /// write_multi_max_size is the max size that services support in write_multi.
+    ///
+    /// For example, AWS S3 supports 5GiB as max in write_multi.
+    ///
+    /// If it is not set, this will be zero
+    pub write_multi_max_size: usize,
+    /// write_multi_min_size is the min size that services support in write_multi.
+    ///
+    /// For example, AWS S3 requires at least 5MiB in write_multi expect the last one.
+    ///
+    /// If it is not set, this will be zero
+    pub write_multi_min_size: usize,
+    /// write_multi_align_size is the align size that services required in write_multi.
+    ///
+    /// For example, Google GCS requires align size to 256KiB in write_multi.
+    ///
+    /// If it is not set, this will be zero
+    pub write_multi_align_size: usize,
+    /// write_total_max_size is the max size that services support in write_total.
+    ///
+    /// For example, Cloudflare D1 supports 1MB as max in write_total.
+    ///
+    /// If it is not set, this will be zero
+    pub write_total_max_size: usize,
+
+    /// If operator supports create dir.
+    pub create_dir: bool,
+
+    /// If operator supports delete.
+    pub delete: bool,
+
+    /// If operator supports copy.
+    pub copy: bool,
+
+    /// If operator supports rename.
+    pub rename: bool,
+
+    /// If operator supports list.
+    pub list: bool,
+    /// If backend supports list with limit.
+    pub list_with_limit: bool,
+    /// If backend supports list with start after.
+    pub list_with_start_after: bool,
+    /// If backend supports list without delimiter.
+    pub list_with_recursive: bool,
+
+    /// If operator supports presign.
+    pub presign: bool,
+    /// If operator supports presign read.
+    pub presign_read: bool,
+    /// If operator supports presign stat.
+    pub presign_stat: bool,
+    /// If operator supports presign write.
+    pub presign_write: bool,
+
+    /// If operator supports batch.
+    pub batch: bool,
+    /// If operator supports batch delete.
+    pub batch_delete: bool,
+    /// The max operations that operator supports in batch.
+    ///
+    /// If it is not set, this will be zero
+    pub batch_max_operations: usize,
+
+    /// If operator supports blocking.
+    pub blocking: bool,
+}
+
+impl opendal_operator_info {
+    /// \brief Get information of underlying accessor.
+    ///
+    /// # Example
+    ///
+    /// ```C
+    /// /// suppose you have a memory-backed opendal_operator* named op
+    /// char *scheme;
+    /// opendal_operator_info *info = opendal_operator_info_new(op);
+    ///
+    /// scheme = opendal_operator_info_get_scheme(info);
+    /// assert(!strcmp(scheme, "memory"));
+    ///
+    /// /// free the heap memory
+    /// free(scheme);
+    /// opendal_operator_info_free(info);
+    /// ```
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_operator_info_new(op: *const opendal_operator) -> *mut Self {
+        let op = (*op).as_ref();
+        let info = op.info();
+
+        Box::into_raw(Box::new(Self {
+            inner: Box::into_raw(Box::new(info)),
+        }))
+    }
+
+    /// \brief Free the heap-allocated opendal_operator_info
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_operator_info_free(ptr: *mut Self) {
+        unsafe {
+            let _ = Box::from_raw((*ptr).inner);
+            let _ = Box::from_raw(ptr);
+        }
+    }
+
+    /// \brief Return the nul-terminated operator's scheme, i.e. service
+    ///
+    /// \note: The string is on heap, remember to free it
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_operator_info_get_scheme(&self) -> *mut c_char {
+        let scheme = (*self.inner).scheme().to_string();
+        CString::new(scheme)
+            .expect("CString::new failed in opendal_operator_info_get_root")
+            .into_raw()
+    }
+
+    /// \brief Return the nul-terminated operator's working root path
+    ///
+    /// \note: The string is on heap, remember to free it
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_operator_info_get_root(&self) -> *mut c_char {
+        let root = (*self.inner).root();
+        CString::new(root)
+            .expect("CString::new failed in opendal_operator_info_get_root")
+            .into_raw()
+    }
+
+    /// \brief Return the nul-terminated operator backend's name, could be empty if underlying backend has no
+    /// namespace concept.
+    ///
+    /// \note: The string is on heap, remember to free it
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_operator_info_get_name(&self) -> *mut c_char {
+        let name = (*self.inner).name();
+        CString::new(name)
+            .expect("CString::new failed in opendal_operator_info_get_name")
+            .into_raw()
+    }
+
+    /// \brief Return the operator's full capability
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_operator_info_get_full_capability(
+        &self,
+    ) -> opendal_capability {
+        let cap = (*self.inner).full_capability();
+        cap.into()
+    }
+
+    /// \brief Return the operator's native capability
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_operator_info_get_native_capability(
+        &self,
+    ) -> opendal_capability {
+        let cap = (*self.inner).native_capability();
+        cap.into()
+    }
+}
+
+impl From<core::Capability> for opendal_capability {
+    fn from(value: core::Capability) -> Self {
+        Self {
+            stat: value.stat,
+            stat_with_if_match: value.stat_with_if_match,
+            stat_with_if_none_match: value.stat_with_if_none_match,
+            read: value.read,
+            read_with_if_match: value.read_with_if_match,
+            read_with_if_none_match: value.read_with_if_none_match,
+            read_with_override_content_type: value.read_with_override_content_type,
+            read_with_override_cache_control: value.read_with_override_cache_control,
+            read_with_override_content_disposition: value.read_with_override_content_disposition,
+            write: value.write,
+            write_can_multi: value.write_can_multi,
+            write_can_empty: value.write_can_empty,
+            write_can_append: value.write_can_append,
+            write_with_content_type: value.write_with_content_type,
+            write_with_content_disposition: value.write_with_content_disposition,
+            write_with_cache_control: value.write_with_cache_control,
+            write_multi_max_size: value.write_multi_max_size.unwrap_or(0),
+            write_multi_min_size: value.write_multi_min_size.unwrap_or(0),
+            write_multi_align_size: value.write_multi_align_size.unwrap_or(0),
+            write_total_max_size: value.write_total_max_size.unwrap_or(0),
+            create_dir: value.create_dir,
+            delete: value.delete,
+            copy: value.copy,
+            rename: value.rename,
+            list: value.list,
+            list_with_limit: value.list_with_limit,
+            list_with_start_after: value.list_with_start_after,
+            list_with_recursive: value.list_with_recursive,
+            presign: value.presign,
+            presign_read: value.presign_read,
+            presign_stat: value.presign_stat,
+            presign_write: value.presign_write,
+            batch: value.batch,
+            batch_delete: value.batch_delete,
+            batch_max_operations: value.batch_max_operations.unwrap_or(0),
+            blocking: value.blocking,
+        }
+    }
+}

--- a/lib/rust/opendal/bindings/c/src/reader.rs
+++ b/lib/rust/opendal/bindings/c/src/reader.rs
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::io::Read;
+
+use ::opendal as core;
+
+use super::*;
+
+/// \brief The result type returned by opendal's reader operation.
+///
+/// \note The opendal_reader actually owns a pointer to
+/// a opendal::BlockingReader, which is inside the Rust core code.
+#[repr(C)]
+pub struct opendal_reader {
+    inner: *mut core::StdReader,
+}
+
+impl opendal_reader {
+    pub(crate) fn new(reader: core::StdReader) -> Self {
+        Self {
+            inner: Box::into_raw(Box::new(reader)),
+        }
+    }
+
+    /// \brief Read data from the reader.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_reader_read(
+        reader: *const Self,
+        buf: *mut u8,
+        len: usize,
+    ) -> opendal_result_reader_read {
+        if buf.is_null() {
+            panic!("The buffer given is pointing at NULL");
+        }
+
+        let buf = unsafe { std::slice::from_raw_parts_mut(buf, len) };
+
+        let inner = unsafe { &mut *(*reader).inner };
+        let n = inner.read(buf);
+        match n {
+            Ok(n) => opendal_result_reader_read {
+                size: n,
+                error: std::ptr::null_mut(),
+            },
+            Err(e) => opendal_result_reader_read {
+                size: 0,
+                error: opendal_error::new(
+                    core::Error::new(core::ErrorKind::Unexpected, "read failed from reader")
+                        .set_source(e),
+                ),
+            },
+        }
+    }
+
+    /// \brief Frees the heap memory used by the opendal_reader.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_reader_free(ptr: *mut opendal_reader) {
+        if !ptr.is_null() {
+            let _ = unsafe { Box::from_raw((*ptr).inner) };
+            let _ = unsafe { Box::from_raw(ptr) };
+        }
+    }
+}

--- a/lib/rust/opendal/bindings/c/src/result.rs
+++ b/lib/rust/opendal/bindings/c/src/result.rs
@@ -1,0 +1,133 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! This is for better naming in C header file. If we use generics for Result type,
+//! it will no doubt work find. However, the generics will lead to naming like
+//! "opendal_result_opendal_operator", which is unacceptable. Therefore,
+//! we are defining all Result types here
+
+use super::*;
+
+/// \brief The result type returned by opendal_operator_new() operation.
+///
+/// If the init logic is successful, the `op` field will be set to a valid
+/// pointer, and the `error` field will be set to null. If the init logic fails, the
+/// `op` field will be set to null, and the `error` field will be set to a
+/// valid pointer with error code and error message.
+///
+/// @see opendal_operator_new()
+/// @see opendal_operator
+/// @see opendal_error
+#[repr(C)]
+pub struct opendal_result_operator_new {
+    /// The pointer for operator.
+    pub op: *mut opendal_operator,
+    /// The error pointer for error.
+    pub error: *mut opendal_error,
+}
+
+/// \brief The result type returned by opendal's read operation.
+///
+/// The result type of read operation in opendal C binding, it contains
+/// the data that the read operation returns and an NULL error.
+/// If the read operation failed, the `data` fields should be a nullptr
+/// and the error is not NULL.
+#[repr(C)]
+pub struct opendal_result_read {
+    /// The byte array with length returned by read operations
+    pub data: *mut opendal_bytes,
+    /// The error, if ok, it is null
+    pub error: *mut opendal_error,
+}
+
+/// \brief The result type returned by opendal_operator_is_exist().
+///
+/// The result type for opendal_operator_is_exist(), the field `is_exist`
+/// contains whether the path exists, and the field `error` contains the
+/// corresponding error. If successful, the `error` field is null.
+///
+/// \note If the opendal_operator_is_exist() fails, the `is_exist` field
+/// will be set to false.
+#[repr(C)]
+pub struct opendal_result_is_exist {
+    /// Whether the path exists
+    pub is_exist: bool,
+    /// The error, if ok, it is null
+    pub error: *mut opendal_error,
+}
+
+/// \brief The result type returned by opendal_operator_stat().
+///
+/// The result type for opendal_operator_stat(), the field `meta` contains the metadata
+/// of the path, the field `error` represents whether the stat operation is successful.
+/// If successful, the `error` field is null.
+#[repr(C)]
+pub struct opendal_result_stat {
+    /// The metadata output of the stat
+    pub meta: *mut opendal_metadata,
+    /// The error, if ok, it is null
+    pub error: *mut opendal_error,
+}
+
+/// \brief The result type returned by opendal_operator_list().
+///
+/// The result type for opendal_operator_list(), the field `lister` contains the lister
+/// of the path, which is an iterator of the objects under the path. the field `error` represents
+/// whether the stat operation is successful. If successful, the `error` field is null.
+#[repr(C)]
+pub struct opendal_result_list {
+    /// The lister, used for further listing operations
+    pub lister: *mut opendal_lister,
+    /// The error, if ok, it is null
+    pub error: *mut opendal_error,
+}
+
+/// \brief The result type returned by opendal_lister_next().
+/// The list entry is the list result of the list operation, the error field is the error code and error message.
+/// If the operation succeeds, the error should be NULL.
+///
+/// \note Please notice if the lister reaches the end, both the list_entry and error will be NULL.
+#[repr(C)]
+pub struct opendal_result_lister_next {
+    /// The next object name
+    pub entry: *mut opendal_entry,
+    /// The error, if ok, it is null
+    pub error: *mut opendal_error,
+}
+
+/// \brief The result type returned by opendal_operator_reader().
+/// The result type for opendal_operator_reader(), the field `reader` contains the reader
+/// of the path, which is an iterator of the objects under the path. the field `code` represents
+/// whether the stat operation is successful.
+#[repr(C)]
+pub struct opendal_result_operator_reader {
+    /// The pointer for opendal_reader
+    pub reader: *mut opendal_reader,
+    /// The error, if ok, it is null
+    pub error: *mut opendal_error,
+}
+
+/// \brief The is the result type returned by opendal_reader_read().
+/// The result type contains a size field, which is the size of the data read,
+/// which is zero on error. The error field is the error code and error message.
+#[repr(C)]
+pub struct opendal_result_reader_read {
+    /// The read size if succeed.
+    pub size: usize,
+    /// The error, if ok, it is null
+    pub error: *mut opendal_error,
+}

--- a/lib/rust/opendal/bindings/c/src/types.rs
+++ b/lib/rust/opendal/bindings/c/src/types.rs
@@ -1,0 +1,148 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+use std::os::raw::c_char;
+
+use opendal::Buffer;
+
+/// \brief opendal_bytes carries raw-bytes with its length
+///
+/// The opendal_bytes type is a C-compatible substitute for Vec type
+/// in Rust, it has to be manually freed. You have to call opendal_bytes_free()
+/// to free the heap memory to avoid memory leak.
+///
+/// @see opendal_bytes_free
+#[repr(C)]
+pub struct opendal_bytes {
+    /// Pointing to the byte array on heap
+    pub data: *const u8,
+    /// The length of the byte array
+    pub len: usize,
+}
+
+impl opendal_bytes {
+    /// Construct a [`opendal_bytes`] from the Rust [`Vec`] of bytes
+    pub(crate) fn new(buf: Buffer) -> Self {
+        let vec = buf.to_vec();
+        let data = vec.as_ptr();
+        let len = vec.len();
+        std::mem::forget(vec);
+        Self { data, len }
+    }
+
+    /// \brief Frees the heap memory used by the opendal_bytes
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_bytes_free(bs: *mut opendal_bytes) {
+        if !bs.is_null() {
+            let data_mut = unsafe { (*bs).data as *mut u8 };
+            // free the vector
+            let _ = unsafe { Vec::from_raw_parts(data_mut, (*bs).len, (*bs).len) };
+            // free the pointer
+            let _ = unsafe { Box::from_raw(bs) };
+        }
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<Buffer> for opendal_bytes {
+    fn into(self) -> Buffer {
+        let slice = unsafe { std::slice::from_raw_parts(self.data, self.len) };
+        Buffer::from(bytes::Bytes::copy_from_slice(slice))
+    }
+}
+
+/// \brief The configuration for the initialization of opendal_operator.
+///
+/// \note This is also a heap-allocated struct, please free it after you use it
+///
+/// @see opendal_operator_new has an example of using opendal_operator_options
+/// @see opendal_operator_options_new This function construct the operator
+/// @see opendal_operator_options_free This function frees the heap memory of the operator
+/// @see opendal_operator_options_set This function allow you to set the options
+#[repr(C)]
+pub struct opendal_operator_options {
+    /// The pointer to the Rust HashMap<String, String>
+    /// Only touch this on judging whether it is NULL.
+    inner: *mut HashMap<String, String>,
+}
+
+impl opendal_operator_options {
+    /// \brief Construct a heap-allocated opendal_operator_options
+    ///
+    /// @return An empty opendal_operator_option, which could be set by
+    /// opendal_operator_option_set().
+    ///
+    /// @see opendal_operator_option_set
+    #[no_mangle]
+    pub extern "C" fn opendal_operator_options_new() -> *mut Self {
+        let map: HashMap<String, String> = HashMap::default();
+        let options = Self {
+            inner: Box::into_raw(Box::new(map)),
+        };
+
+        Box::into_raw(Box::new(options))
+    }
+
+    /// \brief Set a Key-Value pair inside opendal_operator_options
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it dereferences and casts the raw pointers
+    /// Make sure the pointer of `key` and `value` point to a valid string.
+    ///
+    /// # Example
+    ///
+    /// ```C
+    /// opendal_operator_options *options = opendal_operator_options_new();
+    /// opendal_operator_options_set(options, "root", "/myroot");
+    ///
+    /// // .. use your opendal_operator_options
+    ///
+    /// opendal_operator_options_free(options);
+    /// ```
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_operator_options_set(
+        &mut self,
+        key: *const c_char,
+        value: *const c_char,
+    ) {
+        let k = unsafe { std::ffi::CStr::from_ptr(key) }
+            .to_str()
+            .unwrap()
+            .to_string();
+        let v = unsafe { std::ffi::CStr::from_ptr(value) }
+            .to_str()
+            .unwrap()
+            .to_string();
+        (*self.inner).insert(k, v);
+    }
+
+    /// Returns a reference to the underlying [`HashMap<String, String>`]
+    pub(crate) fn as_ref(&self) -> &HashMap<String, String> {
+        unsafe { &*(self.inner) }
+    }
+
+    /// \brief Free the allocated memory used by [`opendal_operator_options`]
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_operator_options_free(
+        options: *const opendal_operator_options,
+    ) {
+        let _ = unsafe { Box::from_raw((*options).inner) };
+        let _ = unsafe { Box::from_raw(options as *mut opendal_operator_options) };
+    }
+}

--- a/lib/rust/opendal/bindings/c/tests/bdd.cpp
+++ b/lib/rust/opendal/bindings/c/tests/bdd.cpp
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "opendal.h"
+}
+
+class OpendalBddTest : public ::testing::Test {
+protected:
+    const opendal_operator* p;
+
+    std::string scheme;
+    std::string path;
+    std::string content;
+
+    void SetUp() override
+    {
+        this->scheme = std::string("memory");
+        this->path = std::string("test");
+        this->content = std::string("Hello, World!");
+
+        opendal_operator_options* options = opendal_operator_options_new();
+        opendal_operator_options_set(options, "root", "/myroot");
+
+        // Given A new OpenDAL Blocking Operator
+        opendal_result_operator_new result = opendal_operator_new(scheme.c_str(), options);
+        EXPECT_TRUE(result.error == nullptr);
+
+        this->p = result.op;
+        EXPECT_TRUE(this->p);
+
+        opendal_operator_options_free(options);
+    }
+
+    void TearDown() override { opendal_operator_free(this->p); }
+};
+
+// Scenario: OpenDAL Blocking Operations
+TEST_F(OpendalBddTest, FeatureTest)
+{
+    // When Blocking write path "test" with content "Hello, World!"
+    const opendal_bytes data = {
+        .data = (uint8_t*)this->content.c_str(),
+        .len = this->content.length(),
+    };
+    opendal_error* error = opendal_operator_write(this->p, this->path.c_str(), data);
+    EXPECT_EQ(error, nullptr);
+
+    // The blocking file "test" should exist
+    opendal_result_is_exist e = opendal_operator_is_exist(this->p, this->path.c_str());
+    EXPECT_EQ(e.error, nullptr);
+    EXPECT_TRUE(e.is_exist);
+
+    // The blocking file "test" entry mode must be file
+    opendal_result_stat s = opendal_operator_stat(this->p, this->path.c_str());
+    EXPECT_EQ(s.error, nullptr);
+    opendal_metadata* meta = s.meta;
+    EXPECT_TRUE(opendal_metadata_is_file(meta));
+
+    // The blocking file "test" content length must be 13
+    EXPECT_EQ(opendal_metadata_content_length(meta), 13);
+
+    // the blocking file "test" last modified time must not be -1
+    EXPECT_FALSE(opendal_metadata_last_modified_ms(meta) != -1);
+    opendal_metadata_free(meta);
+
+    // The blocking file "test" must have content "Hello, World!"
+    struct opendal_result_read r = opendal_operator_read(this->p, this->path.c_str());
+    EXPECT_EQ(r.error, nullptr);
+    EXPECT_EQ(r.data->len, this->content.length());
+    for (int i = 0; i < r.data->len; i++) {
+        EXPECT_EQ(this->content[i], (char)(r.data->data[i]));
+    }
+
+    // The blocking file "test" must have content "Hello, World!" and read into buffer
+    int length = this->content.length();
+    unsigned char buffer[this->content.length()];
+    opendal_result_operator_reader reader = opendal_operator_reader(this->p, this->path.c_str());
+    EXPECT_EQ(reader.error, nullptr);
+    auto rst = opendal_reader_read(reader.reader, buffer, length);
+    EXPECT_EQ(rst.size, length);
+    for (int i = 0; i < this->content.length(); i++) {
+        EXPECT_EQ(this->content[i], buffer[i]);
+    }
+    opendal_reader_free(reader.reader);
+
+    // The blocking file should be deleted
+    error = opendal_operator_delete(this->p, this->path.c_str());
+    EXPECT_EQ(error, nullptr);
+    e = opendal_operator_is_exist(this->p, this->path.c_str());
+    EXPECT_EQ(e.error, nullptr);
+    EXPECT_FALSE(e.is_exist);
+
+    // The deletion operation should be idempotent
+    error = opendal_operator_delete(this->p, this->path.c_str());
+    EXPECT_EQ(error, nullptr);
+
+    opendal_bytes_free(r.data);
+
+    // The directory "tmpdir/" should exist and should be a directory
+    error = opendal_operator_create_dir(this->p, "tmpdir/");
+    EXPECT_EQ(error, nullptr);
+    auto stat = opendal_operator_stat(this->p, "tmpdir/");
+    EXPECT_EQ(stat.error, nullptr);
+    EXPECT_TRUE(opendal_metadata_is_dir(stat.meta));
+    EXPECT_FALSE(opendal_metadata_is_file(stat.meta));
+    opendal_metadata_free(stat.meta);
+    error = opendal_operator_delete(this->p, "tmpdir/");
+    EXPECT_EQ(error, nullptr);
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/lib/rust/opendal/bindings/c/tests/common.hpp
+++ b/lib/rust/opendal/bindings/c/tests/common.hpp
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <vector>
+#include <random>
+
+std::vector<unsigned char> generateRandomBytes(std::size_t size) {
+  // Create a random device to generate random numbers
+  std::random_device rd;
+
+  // Create a random engine and seed it with the random device
+  std::mt19937_64 gen(rd());
+
+  // Create a distribution to produce random bytes
+  std::uniform_int_distribution<unsigned char> dist(0, 255);
+
+  // Create a vector to hold the random bytes
+  std::vector<unsigned char> randomBytes(size);
+
+  // Generate random bytes and store them in the vector
+  for (std::size_t i = 0; i < size; ++i) {
+    randomBytes[i] = dist(gen);
+  }
+
+  return randomBytes;
+}

--- a/lib/rust/opendal/bindings/c/tests/error_msg.cpp
+++ b/lib/rust/opendal/bindings/c/tests/error_msg.cpp
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "gtest/gtest.h"
+extern "C" {
+#include "opendal.h"
+}
+
+class OpendalErrorTest : public ::testing::Test {
+protected:
+    const opendal_operator* p;
+
+    // set up a brand new operator
+    void SetUp() override
+    {
+        opendal_operator_options* options = opendal_operator_options_new();
+        opendal_operator_options_set(options, "root", "/myroot");
+
+        opendal_result_operator_new result = opendal_operator_new("memory", options);
+        EXPECT_TRUE(result.error == nullptr);
+
+        this->p = result.op;
+        EXPECT_TRUE(this->p);
+
+        opendal_operator_options_free(options);
+    }
+
+    void TearDown() override { opendal_operator_free(this->p); }
+};
+
+// Test no memory leak of error message
+TEST_F(OpendalErrorTest, ErrorReadTest)
+{
+    // Initialize a operator for "memory" backend, with no options
+    // The read is supposed to fail
+    opendal_result_read r = opendal_operator_read(this->p, "/testpath");
+    ASSERT_NE(r.error, nullptr);
+    ASSERT_EQ(r.error->code, OPENDAL_NOT_FOUND);
+
+    // Lets check the error message out
+    struct opendal_bytes* error_msg = &r.error->message;
+    ASSERT_NE(error_msg->data, nullptr);
+    ASSERT_GT(error_msg->len, 0);
+
+    // the opendal_bytes read is heap allocated, please free it
+    opendal_bytes_free(r.data);
+
+    // free the error
+    opendal_error_free(r.error);
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/lib/rust/opendal/bindings/c/tests/list.cpp
+++ b/lib/rust/opendal/bindings/c/tests/list.cpp
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "common.hpp"
+#include "gtest/gtest.h"
+#include <cstring>
+
+extern "C" {
+#include "opendal.h"
+}
+
+class OpendalListTest : public ::testing::Test {
+protected:
+    const opendal_operator* p;
+
+    // set up a brand new operator
+    void SetUp() override
+    {
+        opendal_operator_options* options = opendal_operator_options_new();
+        opendal_operator_options_set(options, "root", "/myroot");
+
+        opendal_result_operator_new result = opendal_operator_new("memory", options);
+        EXPECT_TRUE(result.error == nullptr);
+
+        this->p = result.op;
+        EXPECT_TRUE(this->p);
+
+        opendal_operator_options_free(options);
+    }
+
+    void TearDown() override { opendal_operator_free(this->p); }
+};
+
+// Basic use case of list
+TEST_F(OpendalListTest, ListDirTest)
+{
+    std::string dname = "some_random_dir_name_152312";
+    std::string fname = "some_random_file_name_21389";
+
+    // 4 MiB of random bytes
+    uintptr_t nbytes = 4 * 1024 * 1024;
+    auto rand = generateRandomBytes(4 * 1024 * 1024);
+    auto random_bytes = reinterpret_cast<uint8_t*>(rand.data());
+
+    std::string path = dname + "/" + fname;
+    opendal_bytes data = {
+        .data = random_bytes,
+        .len = nbytes,
+    };
+
+    // write must succeed
+    EXPECT_EQ(opendal_operator_write(this->p, path.c_str(), data),
+        nullptr);
+
+    // list must succeed since the write succeeded
+    opendal_result_list l = opendal_operator_list(this->p, (dname + "/").c_str());
+    EXPECT_EQ(l.error, nullptr);
+
+    opendal_lister* lister = l.lister;
+
+    // start checking the lister's result
+    bool found = false;
+
+    opendal_result_lister_next result = opendal_lister_next(lister);
+    EXPECT_EQ(result.error, nullptr);
+    opendal_entry* entry = result.entry;
+    while (entry) {
+        char* de_path = opendal_entry_path(entry);
+
+        // stat must succeed
+        opendal_result_stat s = opendal_operator_stat(this->p, de_path);
+        EXPECT_EQ(s.error, nullptr);
+
+        if (!strcmp(de_path, path.c_str())) {
+            found = true;
+
+            // the path we found has to be a file, and the length must be coherent
+            EXPECT_TRUE(opendal_metadata_is_file(s.meta));
+            EXPECT_EQ(opendal_metadata_content_length(s.meta), nbytes);
+        }
+
+        free(de_path);
+        opendal_metadata_free(s.meta);
+        opendal_entry_free(entry);
+
+        result = opendal_lister_next(lister);
+        EXPECT_EQ(result.error, nullptr);
+        entry = result.entry;
+    }
+
+    // we must have found the file we wrote
+    EXPECT_TRUE(found);
+
+    // delete
+    EXPECT_EQ(opendal_operator_delete(this->p, path.c_str()),
+        nullptr);
+
+    opendal_lister_free(lister);
+}
+
+// todo: Try list an empty directory
+TEST_F(OpendalListTest, ListEmptyDirTest) { }
+
+// todo: Try list a directory that does not exist
+TEST_F(OpendalListTest, ListNotExistDirTest) { }
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/lib/rust/opendal/bindings/c/tests/opinfo.cpp
+++ b/lib/rust/opendal/bindings/c/tests/opinfo.cpp
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "gtest/gtest.h"
+extern "C" {
+#include "opendal.h"
+}
+
+class OpendalOperatorInfoTest : public ::testing::Test {
+protected:
+    opendal_operator* p;
+    opendal_operator_info* info;
+    std::string root;
+    std::string scheme;
+
+    // set up a brand new operator
+    void SetUp() override
+    {
+        this->root = std::string("/myroot/");
+        this->scheme = std::string("memory");
+
+        opendal_operator_options* options = opendal_operator_options_new();
+        opendal_operator_options_set(options, "root", this->root.c_str());
+
+        opendal_result_operator_new result = opendal_operator_new(this->scheme.c_str(), options);
+        EXPECT_TRUE(result.error == nullptr);
+
+        this->p = result.op;
+        EXPECT_TRUE(this->p);
+
+        this->info = opendal_operator_info_new(this->p);
+        EXPECT_TRUE(this->info);
+
+        opendal_operator_options_free(options);
+    }
+
+    void TearDown() override
+    {
+        opendal_operator_free(this->p);
+        opendal_operator_info_free(this->info);
+    }
+};
+
+// We test the capability set by **memory** service.
+TEST_F(OpendalOperatorInfoTest, CapabilityTest)
+{
+    opendal_capability full_cap = opendal_operator_info_get_full_capability(this->info);
+    opendal_capability native_cap = opendal_operator_info_get_native_capability(this->info);
+
+    EXPECT_TRUE(full_cap.blocking);
+    EXPECT_TRUE(full_cap.read);
+    EXPECT_TRUE(full_cap.stat);
+    EXPECT_TRUE(full_cap.write);
+    EXPECT_TRUE(full_cap.write_can_empty);
+    EXPECT_TRUE(full_cap.create_dir);
+    EXPECT_TRUE(full_cap.delete_);
+    EXPECT_TRUE(full_cap.list);
+    EXPECT_TRUE(full_cap.list_with_recursive);
+
+    EXPECT_TRUE(native_cap.blocking);
+    EXPECT_TRUE(native_cap.read);
+    EXPECT_TRUE(native_cap.stat);
+    EXPECT_TRUE(native_cap.write);
+    EXPECT_TRUE(native_cap.write_can_empty);
+    EXPECT_FALSE(native_cap.create_dir);
+    EXPECT_TRUE(native_cap.delete_);
+    EXPECT_TRUE(native_cap.list);
+    EXPECT_TRUE(native_cap.list_with_recursive);
+}
+
+TEST_F(OpendalOperatorInfoTest, InfoTest)
+{
+    char *scheme, *root;
+    scheme = opendal_operator_info_get_scheme(this->info);
+    root = opendal_operator_info_get_root(this->info);
+
+    EXPECT_TRUE(!strcmp(scheme, this->scheme.c_str()));
+    EXPECT_TRUE(!strcmp(root, this->root.c_str()));
+
+    // remember to free the strings
+    free(scheme);
+    free(root);
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/rust/opendal/_demo/memory_demo/error_handle.go
+++ b/rust/opendal/_demo/memory_demo/error_handle.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"github.com/goplus/llgo/c"
+	"github.com/goplus/llgoexamples/rust/opendal"
+)
+
+// this example shows how to get error message from opendal_error
+func main() {
+	/* Initialize a operator for "memory" backend, with no options */
+	result := opendal.NewResultOperator(c.Str("memory"), nil)
+	if result.Op == nil {
+		return
+	}
+	if result.Error != nil {
+		return
+	}
+
+	op := result.Op
+
+	/* The read is supposed to fail */
+	r := op.Read(c.Str("testpath"))
+	if r.Error == nil {
+		return
+	}
+	if r.Error.Code != opendal.NotFound {
+		return
+	}
+
+	/* Lets print the error message out */
+	errorMsg := &r.Error.Message
+	dataSlice := (*[1 << 30]uint8)(c.Pointer(errorMsg.Data))[:errorMsg.Len:errorMsg.Len]
+	for i := 0; i < int(errorMsg.Len); i++ {
+		c.Printf(c.Str("%c"), dataSlice[i])
+	}
+
+	/* free the error since the error is not NULL */
+	r.Error.Free()
+
+	/* the operator_ptr is also heap allocated */
+	op.Free()
+}

--- a/rust/opendal/_demo/memory_demo/opendal.go
+++ b/rust/opendal/_demo/memory_demo/opendal.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"github.com/goplus/llgo/c"
+	"github.com/goplus/llgoexamples/rust/opendal"
+)
+
+func main() {
+
+	/* Initialize a operator for "memory" backend, with no options */
+	result := opendal.NewResultOperator(c.Str("memory"), nil)
+
+	if result.Op == nil {
+		return
+	}
+	if result.Error != nil {
+		return
+	}
+
+	op := result.Op
+
+	/* Prepare some data to be written */
+	data := opendal.Bytes{
+		Data: (*uint8)(c.Pointer(c.Str("this_string_length_is_24"))),
+		Len:  c.Ulong(24),
+	}
+
+	/* Write this into path "/testpath" */
+	error := op.OperatorWrite(c.Str("/testpath"), data)
+	if error != nil {
+		return
+	}
+
+	/* We can read it out, make sure the data is the same */
+	r := op.OperatorRead(c.Str("/testpath"))
+	readBytes := r.Data
+	if r.Error != nil {
+		return
+	}
+	if readBytes.Len != 24 {
+		return
+	}
+
+	/* Lets print it out */
+	dataSlice := (*[1 << 6]uint8)(c.Pointer(readBytes.Data))[:readBytes.Len:readBytes.Len]
+
+	for i := 0; i < 24; i++ {
+		c.Printf(c.Str("%c"), dataSlice[i])
+	}
+
+	c.Printf(c.Str("\n"))
+
+	/* the opendal_bytes read is heap allocated, please free it */
+	readBytes.FreeBytes()
+	/* the operator_ptr is also heap allocated */
+	op.FreeOperator()
+}

--- a/rust/opendal/opendal.go
+++ b/rust/opendal/opendal.go
@@ -1,0 +1,53 @@
+package opendal
+
+import (
+	_ "unsafe"
+
+	"github.com/goplus/llgo/c"
+)
+
+const (
+	LLGoPackage = "link: $(pkg-config --libs opendal_c); -lopendal_c"
+)
+
+type ResultOperator struct {
+	Op    *Operator
+	Error *Error
+}
+
+type OperatorOptions struct {
+	Unused [8]byte
+}
+
+type Error struct {
+	Unused [8]byte
+}
+
+type Operator struct {
+	Unused [8]byte
+}
+
+type Bytes struct {
+	Data *uint8
+	Len  c.Ulong
+}
+
+type ResultRead struct {
+	Data  *Bytes
+	Error *Error
+}
+
+// llgo:link NewResultOperator C.opendal_operator_new
+func NewResultOperator(schema *c.Char, options *OperatorOptions) (rst ResultOperator) { return }
+
+// llgo:link (*Operator).OperatorWrite C.opendal_operator_write
+func (op *Operator) OperatorWrite(path *c.Char, bytes Bytes) *Error { return nil }
+
+// llgo:link (*Operator).OperatorRead C.opendal_operator_read
+func (op *Operator) OperatorRead(path *c.Char) (rst ResultRead) { return }
+
+// llgo:link (*Bytes).FreeBytes C.opendal_bytes_free
+func (bs *Bytes) FreeBytes() {}
+
+// llgo:link (*Operator).FreeOperator C.opendal_operator_free
+func (op *Operator) FreeOperator() {}

--- a/rust/opendal/opendal.go
+++ b/rust/opendal/opendal.go
@@ -10,21 +10,76 @@ const (
 	LLGoPackage = "link: $(pkg-config --libs opendal_c); -lopendal_c"
 )
 
+type Code c.Int
+
+/**
+ * \brief The error code for all opendal APIs in C binding.
+ * \todo The error handling is not complete, the error with error message will be
+ * added in the future.
+ */
+const (
+	/*
+	 * returning it back. For example, s3 returns an internal service error.
+	 */
+	Unexpected Code = iota
+	/*
+	 * Underlying service doesn't support this operation.
+	 */
+	Unsupported
+	/*
+	 * The config for backend is invalid.
+	 */
+	ConfigInvalid
+	/*
+	 * The given path is not found.
+	 */
+	NotFound
+	/*
+	 * The given path doesn't have enough permission for this operation
+	 */
+	PermissionDenied
+	/*
+	 * The given path is a directory.
+	 */
+	IsADirectory
+	/*
+	 * The given path is not a directory.
+	 */
+	NotADirectory
+	/*
+	 * The given path already exists thus we failed to the specified operation on it.
+	 */
+	AlreadyExists
+	/*
+	 * Requests that sent to this path is over the limit, please slow down.
+	 */
+	RateLimited
+	/*
+	 * The given file paths are same.
+	 */
+	IsSameFile
+	/*
+	 * The condition of this operation is not match.
+	 */
+	ConditionNotMatch
+	/*
+	 * The range of the content is not satisfied.
+	 */
+	RangeNotSatisfied
+)
+
 type ResultOperator struct {
 	Op    *Operator
 	Error *Error
 }
 
 type OperatorOptions struct {
-	Unused [8]byte
+	Inner *HashMapStringString
 }
 
 type Error struct {
-	Unused [8]byte
-}
-
-type Operator struct {
-	Unused [8]byte
+	Code    Code
+	Message Bytes
 }
 
 type Bytes struct {
@@ -37,17 +92,88 @@ type ResultRead struct {
 	Error *Error
 }
 
+type BlockingLister struct {
+	Unused [8]byte
+}
+
+type BlockingOperator struct {
+	Unused [8]byte
+}
+
+type Operator struct {
+	Ptr *BlockingOperator
+}
+
+type InnerEntry struct {
+	Unused [8]byte
+}
+
+type HashMapStringString struct {
+	Unused [8]byte
+}
+
+type InnerMetadata struct {
+	Unused [8]byte
+}
+
+type OperatorInfo struct {
+	Unused [8]byte
+}
+
+type StdReader struct {
+	Unused [8]byte
+}
+
+type Entry struct {
+	Inner *InnerEntry
+}
+
+type ResultListerNext struct {
+	Entry *Entry
+	Error *Error
+}
+
+type Lister struct {
+	Inner *BlockingLister
+}
+
+type MetaData struct {
+	Inner *InnerMetadata
+}
+
+type Reader struct {
+	Inner *StdReader
+}
+
+type ResultOperatorReader struct {
+	Reader *Reader
+	Error  *Error
+}
+
+type ResultIsExist struct {
+	IsExist int8
+	Error   *Error
+}
+
+type ResultStat struct {
+	Meta  *MetaData
+	Error *Error
+}
+
 // llgo:link NewResultOperator C.opendal_operator_new
 func NewResultOperator(schema *c.Char, options *OperatorOptions) (rst ResultOperator) { return }
 
-// llgo:link (*Operator).OperatorWrite C.opendal_operator_write
-func (op *Operator) OperatorWrite(path *c.Char, bytes Bytes) *Error { return nil }
+// llgo:link (*Operator).Write C.opendal_operator_write
+func (op *Operator) Write(path *c.Char, bytes Bytes) *Error { return nil }
 
-// llgo:link (*Operator).OperatorRead C.opendal_operator_read
-func (op *Operator) OperatorRead(path *c.Char) (rst ResultRead) { return }
+// llgo:link (*Operator).Read C.opendal_operator_read
+func (op *Operator) Read(path *c.Char) (rst ResultRead) { return }
 
-// llgo:link (*Bytes).FreeBytes C.opendal_bytes_free
-func (bs *Bytes) FreeBytes() {}
+// llgo:link (*Bytes).Free C.opendal_bytes_free
+func (bs *Bytes) Free() {}
 
-// llgo:link (*Operator).FreeOperator C.opendal_operator_free
-func (op *Operator) FreeOperator() {}
+// llgo:link (*Operator).Free C.opendal_operator_free
+func (op *Operator) Free() {}
+
+// llgo:link (*Error).Free C.opendal_error_free
+func (err *Error) Free() {}


### PR DESCRIPTION
Opendal is a data operations middle layer
Now the function and type used in the header file of the c-demo have been migrated, and the official demo has been run in LLGO